### PR TITLE
Handle `structure.sql`

### DIFF
--- a/app/controllers/rails_ruby_lsp/models_controller.rb
+++ b/app/controllers/rails_ruby_lsp/models_controller.rb
@@ -9,9 +9,16 @@ module RailsRubyLsp
     def show
       const = Object.const_get(params[:id]) # rubocop:disable Sorbet/ConstantsFromStrings
 
+      begin
+        schema_file = ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(const.connection.pool.db_config)
+      rescue => e
+        warn("Could not locate schema: #{e.message}")
+      end
+
       if const < ActiveRecord::Base
         render(json: {
           columns: const.columns.map { |column| [column.name, column.type] },
+          schema_file: schema_file,
         })
       else
         head(:not_found)

--- a/lib/ruby_lsp/rails_ruby_lsp/hover.rb
+++ b/lib/ruby_lsp/rails_ruby_lsp/hover.rb
@@ -25,9 +25,11 @@ module RailsRubyLsp
         model = RailsClient.instance.model(node.value)
         return if model.nil?
 
-        schema_file = File.join(RailsClient.instance.root, "db", "schema.rb")
+        schema_file = model[:schema_file]
         content = +""
-        content << "[Schema](file://#{schema_file})\n\n" if File.exist?(schema_file)
+        if schema_file
+          content << "[Schema](file://#{schema_file})\n\n"
+        end
         content << model[:columns].map { |name, type| "**#{name}**: #{type}\n" }.join("\n")
         contents = RubyLsp::Interface::MarkupContent.new(kind: "markdown", value: content)
         @response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)

--- a/test/controllers/rails_ruby_lsp/models_controller_test.rb
+++ b/test/controllers/rails_ruby_lsp/models_controller_test.rb
@@ -7,11 +7,12 @@ module RailsRubyLsp
   class ModelsControllerTest < ActionDispatch::IntegrationTest
     T.unsafe(self).include(Engine.routes.url_helpers)
 
-    test "GET show returns column information for exsting models" do
+    test "GET show returns column information for existing models" do
       get model_url(id: "User")
       assert_response(:success)
       assert_equal(
         {
+          "schema_file" => "#{RailsClient.instance.root}/db/schema.rb",
           "columns" => [
             ["id", "integer"],
             ["first_name", "string"],

--- a/test/lib/hover_test.rb
+++ b/test/lib/hover_test.rb
@@ -7,6 +7,7 @@ module RailsRubyLsp
   class HoverTest < ActiveSupport::TestCase
     test "hook returns model column information" do
       expected_response = {
+        schema_file: "#{RailsClient.instance.root}/db/schema.rb",
         columns: [
           ["id", "integer"],
           ["first_name", "string"],
@@ -40,6 +41,43 @@ module RailsRubyLsp
 
         **updated_at**: datetime
       CONTENT
+    end
+
+    test "handles `db/structure.sql` instead of `db/schema.rb`" do
+      expected_response = {
+        schema_file: "#{RailsClient.instance.root}/db/structure.sql",
+        columns: [],
+      }
+
+      listener = Hover.new
+
+      stub_http_request("200", expected_response.to_json) do
+        RailsClient.instance.stub(:check_if_server_is_running!, true) do
+          RubyLsp::EventEmitter.new(listener).emit_for_target(Const("User"))
+        end
+      end
+
+      assert_includes(
+        T.must(listener.response).contents.value,
+        "[Schema](file://#{RailsClient.instance.root}/db/structure.sql)",
+      )
+    end
+
+    test "handles neither `db/structure.sql` nor `db/schema.rb` being present" do
+      expected_response = {
+        schema_file: nil,
+        columns: [],
+      }
+
+      listener = Hover.new
+
+      stub_http_request("200", expected_response.to_json) do
+        RailsClient.instance.stub(:check_if_server_is_running!, true) do
+          RubyLsp::EventEmitter.new(listener).emit_for_target(Const("User"))
+        end
+      end
+
+      refute_match(/Schema/, T.must(listener.response).contents.value)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,8 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixtures(:all)
 end
 
+$VERBOSE = nil unless ENV["VERBOSE"] || ENV["CI"]
+
 module ActiveSupport
   class TestCase
     include SyntaxTree::DSL


### PR DESCRIPTION
Closes #9

## Tophatting

Create a sample Rails app configured with `config.active_record.schema_format = :sql` in `config/application.rb`, and add `rails_ruby_lsp` to the Gemfile, pointing to this branch. Add an example model and run the migration. Hover over the model name and ensure you can click through to the `db/structure.sql` file.