### PR TITLE
Add sorbet-runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
     rails_ruby_lsp (0.1.0)
       rails (>= 7.0.4.3)
       ruby-lsp (>= 0.4.0)
+      sorbet-runtime (>= 0.5.9897)
 
 GEM
   remote: https://rubygems.org/

--- a/rails_ruby_lsp.gemspec
+++ b/rails_ruby_lsp.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("rails", ">= 7.0.4.3")
   spec.add_dependency("ruby-lsp", ">= 0.4.0")
+  spec.add_dependency("sorbet-runtime", ">= 0.5.9897")
 end


### PR DESCRIPTION
Although `sorbet-static-and-runtime` is in the Gemfile, we need `sorbet-runtime` in the gemspec.

I choose a version of `sorbet-runtime` from one year ago as a reasonable minimum.