### PR TITLE
Rename model parameter

### DIFF
--- a/app/controllers/ruby_lsp/rails/models_controller.rb
+++ b/app/controllers/ruby_lsp/rails/models_controller.rb
@@ -8,7 +8,7 @@ module RubyLsp
 
       sig { returns(T.untyped) }
       def show
-        const = Object.const_get(params[:id]) # rubocop:disable Sorbet/ConstantsFromStrings
+        const = Object.const_get(params[:model]) # rubocop:disable Sorbet/ConstantsFromStrings
 
         begin
           schema_file = ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(const.connection.pool.db_config)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 RubyLsp::Rails::Engine.routes.draw do
-  resources :models, only: [:show]
+  resources :models, only: [:show], param: :model
 end

--- a/sorbet/rbi/shims/actiondispatch.rbi
+++ b/sorbet/rbi/shims/actiondispatch.rbi
@@ -3,7 +3,7 @@
 
 module ActionDispatch
   class IntegrationTest
-    sig { params(id: String).returns(String) }
-    def model_url(id:); end
+    sig { params(model: String).returns(String) }
+    def model_url(model:); end
   end
 end

--- a/test/controllers/ruby_lsp_rails/models_controller_test.rb
+++ b/test/controllers/ruby_lsp_rails/models_controller_test.rb
@@ -9,7 +9,7 @@ module RubyLsp
       T.unsafe(self).include(Engine.routes.url_helpers)
 
       test "GET show returns column information for existing models" do
-        get model_url(id: "User")
+        get model_url(model: "User")
         assert_response(:success)
         assert_equal(
           {
@@ -28,12 +28,12 @@ module RubyLsp
       end
 
       test "GET show returns not_found if model doesn't exist" do
-        get model_url(id: "NonExistentModel")
+        get model_url(model: "NonExistentModel")
         assert_response(:not_found)
       end
 
       test "GET show returns not_found if class is not a model" do
-        get model_url(id: "ApplicationJob")
+        get model_url(model: "ApplicationJob")
         assert_response(:not_found)
       end
     end


### PR DESCRIPTION
Since `id` isn't a DB key, I think it's better to rename.