### PR TITLE
Find the correct project root when using custom bundle

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -5,7 +5,6 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path("..", __dir__)
-ENGINE_PATH = File.expand_path("../lib/ruby_lsp_rails/engine", __dir__)
 APP_PATH = File.expand_path("../test/dummy/config/application", __dir__)
 
 # Set up gems listed in the Gemfile.

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
@@ -22,6 +22,11 @@ module RubyLsp
       sig { void }
       def initialize
         project_root = Pathname.new(ENV["BUNDLE_GEMFILE"]).dirname
+
+        if project_root.basename.to_s == ".ruby-lsp"
+          project_root = project_root.sub("/.ruby-lsp", "")
+        end
+
         dummy_path = File.join(project_root, "test", "dummy")
         @root = T.let(Dir.exist?(dummy_path) ? dummy_path : project_root.to_s, String)
         app_uri_path = "#{@root}/tmp/app_uri.txt"

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
@@ -24,7 +24,7 @@ module RubyLsp
         project_root = Pathname.new(ENV["BUNDLE_GEMFILE"]).dirname
 
         if project_root.basename.to_s == ".ruby-lsp"
-          project_root = project_root.sub("/.ruby-lsp", "")
+          project_root = project_root.join("../")
         end
 
         dummy_path = File.join(project_root, "test", "dummy")

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,6 +1,3 @@
-# typed: true
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -15,10 +12,11 @@
 
 ActiveRecord::Schema[7.0].define(version: 2023_03_30_202955) do
   create_table "users", force: :cascade do |t|
-    t.string("first_name")
-    t.string("last_name")
-    t.integer("age")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+    t.string "first_name"
+    t.string "last_name"
+    t.integer "age"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
+
 end

--- a/test/lib/rails_client_test.rb
+++ b/test/lib/rails_client_test.rb
@@ -38,6 +38,21 @@ module RubyLsp
       ensure
         File.write(T.must(app_uri_path), "http://localhost:3000")
       end
+
+      test "instantiation finds the right directory when bundle gemfile points to .ruby-lsp" do
+        previous_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
+        project_root = Pathname.new(previous_bundle_gemfile).dirname
+
+        # If the RailsClient singleton was initialized in a different test successfully, then there would be no chance
+        # for this assertion to pass. We need to reset the singleton instance in order to force `initialize` to be
+        # executed again
+        Singleton.send(:__init__, RailsClient)
+
+        ENV["BUNDLE_GEMFILE"] = "#{project_root}/.ruby-lsp/Gemfile"
+        assert_equal("#{project_root}/test/dummy", RailsClient.instance.root)
+      ensure
+        ENV["BUNDLE_GEMFILE"] = previous_bundle_gemfile
+      end
     end
   end
 end


### PR DESCRIPTION
When we're pointing the custom bundle to the `.ruby-lsp` folder, then the project root is one folder above of it. We need to account for this when discovering the root.

I also fixed the `bin/rails` script which was broke after changing strategy to use a middleware. The schema file was changed possibly because it had some RuboCop changes. Those weren't really relevant, so I just updated to what Rails dumps for us.