### PR TITLE
Use middleware to check if server is running instead of checking PID

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
@@ -38,8 +38,14 @@ module RubyLsp
           MESSAGE
         end
 
-        base_uri = File.read(app_uri_path).chomp
-        @uri = T.let("#{base_uri}/ruby_lsp_rails", String)
+        url = File.read(app_uri_path).chomp
+
+        scheme, rest = url.split("://")
+        uri, port = T.must(rest).split(":")
+
+        @ssl = T.let(scheme == "https", T::Boolean)
+        @uri = T.let(T.must(uri), String)
+        @port = T.let(T.must(port).to_i, Integer)
       end
 
       sig { params(name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -54,28 +60,22 @@ module RubyLsp
 
       sig { void }
       def check_if_server_is_running!
-        # Check if the Rails server is running. Warn the user to boot it for Rails features
-        pid_file = ENV.fetch("PIDFILE") { File.join(@root, "tmp", "pids", "server.pid") }
-
-        # If the PID file doesn't exist, then the server hasn't been booted
-        raise ServerNotRunningError, SERVER_NOT_RUNNING_MESSAGE unless File.exist?(pid_file)
-
-        pid = File.read(pid_file).to_i
-
-        begin
-          # Issuing an EXIT signal to an existing process actually doesn't make the server shutdown. But if this
-          # call succeeds, then the server is running. If the PID doesn't exist, Errno::ESRCH is raised
-          Process.kill(T.must(Signal.list["EXIT"]), pid)
-        rescue Errno::ESRCH
-          raise ServerNotRunningError, SERVER_NOT_RUNNING_MESSAGE
-        end
+        request("activate", 0.2)
+      rescue Errno::ECONNREFUSED
+        raise ServerNotRunningError, SERVER_NOT_RUNNING_MESSAGE
+      rescue Net::ReadTimeout
+        # If the server is running, but the initial request is taking too long, we don't want to block the
+        # initialization of the Ruby LSP
       end
 
       private
 
-      sig { params(path: String).returns(Net::HTTPResponse) }
-      def request(path)
-        Net::HTTP.get_response(URI("#{@uri}/#{path}"))
+      sig { params(path: String, timeout: T.nilable(Float)).returns(Net::HTTPResponse) }
+      def request(path, timeout = nil)
+        http = Net::HTTP.new(@uri, @port)
+        http.use_ssl = @ssl
+        http.read_timeout = timeout if timeout
+        http.get("/ruby_lsp_rails/#{path}")
       end
     end
   end

--- a/test/ruby_lsp_rails/middleware_test.rb
+++ b/test/ruby_lsp_rails/middleware_test.rb
@@ -34,6 +34,11 @@ module RubyLsp
         get "/ruby_lsp_rails/models/ApplicationJob"
         assert_response(:not_found)
       end
+
+      test "GET activate returns success to display that server is running" do
+        get "/ruby_lsp_rails/activate"
+        assert_response(:success)
+      end
     end
   end
 end

--- a/test/ruby_lsp_rails/rails_client_test.rb
+++ b/test/ruby_lsp_rails/rails_client_test.rb
@@ -53,6 +53,14 @@ module RubyLsp
       ensure
         ENV["BUNDLE_GEMFILE"] = previous_bundle_gemfile
       end
+
+      test "check_if_server_is_running! raises if no server is found" do
+        Net::HTTP.any_instance.expects(:get).raises(Errno::ECONNREFUSED)
+
+        assert_raises(RailsClient::ServerNotRunningError) do
+          RailsClient.instance.check_if_server_is_running!
+        end
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ module ActiveSupport
       response.expects(:code).returns("200")
       response.expects(:body).returns(body)
 
-      Net::HTTP.stubs(:get_response).returns(response)
+      Net::HTTP.any_instance.expects(:get).returns(response)
     end
 
     def setup


### PR DESCRIPTION
Closes #57

Using the PID to check if the server is running is brittle - and doesn't work in the case of containers like docker. We can just use our own middleware to verify if the server is running since we know the uri and the port.

This PR changes the middleware to accept an `activate` request, which just returns `200` if the server is running.

If the activate request is taking too long to be fulfilled, then I used a timeout to cut the request short. If the request is taking long, it's likely the server is in fact running it's just being slow to respond - and we don't want to block the initialization of the Ruby LSP.