### PR TITLE
Add code lens extension (for Rails tests)

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -1,0 +1,74 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Rails
+    class CodeLens < ::RubyLsp::Listener
+      extend T::Sig
+      extend T::Generic
+
+      ResponseType = type_member { { fixed: T.nilable(T::Array[::RubyLsp::Interface::CodeLens]) } }
+
+      ::RubyLsp::Requests::CodeLens.add_listener(self)
+
+      sig { override.returns(ResponseType) }
+      attr_reader :response
+
+      sig { params(uri: String, message_queue: Thread::Queue).void }
+      def initialize(uri, message_queue)
+        @response = T.let([], ResponseType)
+        @visibility = T.let("public", String)
+        @prev_visibility = T.let("public", String)
+        @path = T.let(uri.delete_prefix("file://"), String)
+        super
+      end
+
+      listener_events do
+        sig { params(node: SyntaxTree::Command).void }
+        def on_command(node)
+          if @visibility == "public"
+            message_value = node.message.value
+            if message_value == "test" && node.arguments.parts.any?
+              first_argument = node.arguments.parts.first
+              method_name = first_argument.parts.first.value if first_argument.is_a?(SyntaxTree::StringLiteral)
+
+              if method_name
+                add_code_lens(
+                  node,
+                  name: method_name,
+                  command: RubyLsp::Requests::CodeLens::BASE_COMMAND + @path + " --name " + "test_" + method_name.gsub(
+                    " ", "_"
+                  ),
+                )
+              end
+            end
+          end
+        end
+
+        sig { params(node: SyntaxTree::DefNode).void }
+        def on_def(node); end
+      end
+
+      private
+
+      sig { params(node: SyntaxTree::Node, name: String, command: String).void }
+      def add_code_lens(node, name:, command:)
+        @response << ::RubyLsp::Requests::CodeLens.create_code_lens(
+          node,
+          path: @path,
+          name: name,
+          test_command: command,
+          type: "test",
+        )
+
+        @response << ::RubyLsp::Requests::CodeLens.create_code_lens(
+          node,
+          path: @path,
+          name: name,
+          test_command: command,
+          type: "debug",
+        )
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/ruby_lsp_rails/extension.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/extension.rb
@@ -5,6 +5,7 @@ require "ruby_lsp/extension"
 
 require_relative "rails_client"
 require_relative "hover"
+require_relative "code_lens"
 
 module RubyLsp
   module Rails

--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -14,8 +14,8 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :response
 
-      sig { void }
-      def initialize
+      sig { params(uri: String, message_queue: Thread::Queue).void }
+      def initialize(uri, message_queue)
         @response = T.let(nil, ResponseType)
         super
       end

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyLsp
+  module Rails
+    class CodeLensTest < ActiveSupport::TestCase
+      test "recognizes Rails active support test cases" do
+        message_queue = Thread::Queue.new
+        listener = CodeLens.new("", message_queue)
+
+        test_name = "handles test case"
+
+        RubyLsp::EventEmitter.new(listener).emit_for_target(Command(
+          Ident("test"),
+          Args([StringLiteral([TStringContent(test_name)], "")]),
+          BodyStmt(SyntaxTree::VoidStmt, "", "", "", ""),
+        ))
+
+        assert_equal(test_name, T.must(T.must(listener.response).first).command.arguments[1])
+      end
+    end
+  end
+end

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -19,7 +19,8 @@ module RubyLsp
           ],
         }
 
-        listener = Hover.new
+        message_queue = Thread::Queue.new
+        listener = Hover.new("", message_queue)
 
         stub_http_request("200", expected_response.to_json)
         RailsClient.instance.stubs(check_if_server_is_running!: true)
@@ -48,7 +49,8 @@ module RubyLsp
           columns: [],
         }
 
-        listener = Hover.new
+        message_queue = Thread::Queue.new
+        listener = Hover.new("", message_queue)
 
         stub_http_request("200", expected_response.to_json)
         RailsClient.instance.stubs(check_if_server_is_running!: true)
@@ -66,7 +68,8 @@ module RubyLsp
           columns: [],
         }
 
-        listener = Hover.new
+        message_queue = Thread::Queue.new
+        listener = Hover.new("", message_queue)
 
         stub_http_request("200", expected_response.to_json)
         RailsClient.instance.stubs(check_if_server_is_running!: true)


### PR DESCRIPTION
⚠️ Must be merged after https://github.com/Shopify/ruby-lsp/pull/666

### Description 

Add code lens extension to recognize Rails tests:

```ruby
test "should test something" do
    # assert something
end
```

A Rails test is a `SyntaxTree::Command` with the test name as the first argument so the extension implements `on_command` to create code lenses for Rails tests.

https://github.com/Shopify/ruby-lsp/pull/666 adds parameters to `initialize` so I also updated the hover extension + tests.

### Testing

Created `code_lens_test.rb` that checks that Rails-styled tests are recognized and a `CodeLens` response is created.

You can also manually test by checking out this branch and running the tests in `code_lens_test.rb` from the file.
- Note: Until https://github.com/Shopify/ruby-lsp/pull/666 is merged, you must make sure the `ruby-lsp` gem is installed from [this branch](https://github.com/Shopify/ruby-lsp/tree/al/refactor-code-lens)