### PR TITLE
Bump to Ruby LSP v0.5.1 and fix breaking changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-lsp-rails (0.1.0)
       rails (>= 6.0)
-      ruby-lsp (~> 0.4.5)
+      ruby-lsp (~> 0.5.1)
       sorbet-runtime (>= 0.5.9897)
 
 GEM
@@ -189,7 +189,7 @@ GEM
       rubocop (~> 1.50)
     rubocop-sorbet (0.7.0)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.4.5)
+    ruby-lsp (0.5.1)
       language_server-protocol (~> 3.17.0)
       sorbet-runtime
       syntax_tree (>= 6.1.1, < 7)

--- a/ruby-lsp-rails.gemspec
+++ b/ruby-lsp-rails.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency("rails", ">= 6.0")
-  spec.add_dependency("ruby-lsp", "~> 0.4.5")
+  spec.add_dependency("ruby-lsp", "~> 0.5.1")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9897")
 end


### PR DESCRIPTION
Bump our dependency to the latest LSP version and fix the related breaking changes in how we instantiate listeners.

There are no functional changes in this PR.