### PR TITLE
Remove RuboCop from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "puma"
 gem "sqlite3"
 gem "debug", ">= 1.7.0"
 gem "mocha"
-gem "rubocop", "~> 1.51", require: false
 gem "rubocop-shopify", "~> 2.13", require: false
 gem "rubocop-minitest", "~> 0.31.0", require: false
 gem "rubocop-rake", "~> 0.6.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,6 @@ DEPENDENCIES
   mocha
   puma
   rdoc
-  rubocop (~> 1.51)
   rubocop-minitest (~> 0.31.0)
   rubocop-rake (~> 0.6.0)
   rubocop-shopify (~> 2.13)


### PR DESCRIPTION
Since we already have `rubocop-shopify`, there's no need to have `rubocop`. This should result in less Dependabot notifications.