### PR TITLE
Change how we warn about server not running

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/extension.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/extension.rb
@@ -13,7 +13,6 @@ module RubyLsp
 
       sig { override.void }
       def activate
-        # Must be the last statement in activate since it raises to display a notification for the user
         RubyLsp::Rails::RailsClient.instance.check_if_server_is_running!
       end
 

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
@@ -7,8 +7,7 @@ require "net/http"
 module RubyLsp
   module Rails
     class RailsClient
-      class ServerNotRunningError < StandardError; end
-      class NeedsRestartError < StandardError; end
+      class ServerAddressUnknown < StandardError; end
 
       extend T::Sig
       include Singleton
@@ -31,21 +30,16 @@ module RubyLsp
         @root = T.let(Dir.exist?(dummy_path) ? dummy_path : project_root.to_s, String)
         app_uri_path = "#{@root}/tmp/app_uri.txt"
 
-        unless File.exist?(app_uri_path)
-          raise NeedsRestartError, <<~MESSAGE
-            The Ruby LSP Rails extension needs to be initialized. Please restart the Rails server and the Ruby LSP
-            to get Rails features in the editor
-          MESSAGE
+        if File.exist?(app_uri_path)
+          url = File.read(app_uri_path).chomp
+
+          scheme, rest = url.split("://")
+          uri, port = T.must(rest).split(":")
+
+          @ssl = T.let(scheme == "https", T::Boolean)
+          @uri = T.let(T.must(uri), T.nilable(String))
+          @port = T.let(T.must(port).to_i, Integer)
         end
-
-        url = File.read(app_uri_path).chomp
-
-        scheme, rest = url.split("://")
-        uri, port = T.must(rest).split(":")
-
-        @ssl = T.let(scheme == "https", T::Boolean)
-        @uri = T.let(T.must(uri), String)
-        @port = T.let(T.must(port).to_i, Integer)
       end
 
       sig { params(name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -54,15 +48,15 @@ module RubyLsp
         return unless response.code == "200"
 
         JSON.parse(response.body.chomp, symbolize_names: true)
-      rescue Errno::ECONNREFUSED
-        raise ServerNotRunningError, SERVER_NOT_RUNNING_MESSAGE
+      rescue Errno::ECONNREFUSED, ServerAddressUnknown
+        nil
       end
 
       sig { void }
       def check_if_server_is_running!
         request("activate", 0.2)
-      rescue Errno::ECONNREFUSED
-        raise ServerNotRunningError, SERVER_NOT_RUNNING_MESSAGE
+      rescue Errno::ECONNREFUSED, ServerAddressUnknown
+        warn(SERVER_NOT_RUNNING_MESSAGE)
       rescue Net::ReadTimeout
         # If the server is running, but the initial request is taking too long, we don't want to block the
         # initialization of the Ruby LSP
@@ -72,6 +66,8 @@ module RubyLsp
 
       sig { params(path: String, timeout: T.nilable(Float)).returns(Net::HTTPResponse) }
       def request(path, timeout = nil)
+        raise ServerAddressUnknown unless @uri
+
         http = Net::HTTP.new(@uri, @port)
         http.use_ssl = @ssl
         http.read_timeout = timeout if timeout

--- a/test/ruby_lsp_rails/rails_client_test.rb
+++ b/test/ruby_lsp_rails/rails_client_test.rb
@@ -22,23 +22,6 @@ module RubyLsp
         assert_equal(expected_response, RailsClient.instance.model("User"))
       end
 
-      test "raises during instantiation if app_uri file doesn't exist" do
-        project_root = Pathname.new(ENV["BUNDLE_GEMFILE"]).dirname
-        app_uri_path = "#{project_root}/test/dummy/tmp/app_uri.txt"
-        FileUtils.rm(app_uri_path)
-
-        # If the RailsClient singleton was initialized in a different test successfully, then there would be no chance
-        # for this assertion to pass. We need to reset the singleton instance in order to force `initialize` to be
-        # executed again
-        Singleton.send(:__init__, RailsClient)
-
-        assert_raises(RailsClient::NeedsRestartError) do
-          RailsClient.instance
-        end
-      ensure
-        File.write(T.must(app_uri_path), "http://localhost:3000")
-      end
-
       test "instantiation finds the right directory when bundle gemfile points to .ruby-lsp" do
         previous_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
         project_root = Pathname.new(previous_bundle_gemfile).dirname
@@ -57,7 +40,7 @@ module RubyLsp
       test "check_if_server_is_running! raises if no server is found" do
         Net::HTTP.any_instance.expects(:get).raises(Errno::ECONNREFUSED)
 
-        assert_raises(RailsClient::ServerNotRunningError) do
+        assert_output("", RailsClient::SERVER_NOT_RUNNING_MESSAGE + "\n") do
           RailsClient.instance.check_if_server_is_running!
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,8 +13,6 @@ require "syntax_tree/dsl"
 require "ruby_lsp/internal"
 require "ruby_lsp/ruby_lsp_rails/extension"
 
-$VERBOSE = nil unless ENV["VERBOSE"] || ENV["CI"]
-
 module ActiveSupport
   class TestCase
     include SyntaxTree::DSL


### PR DESCRIPTION
There are legitimate cases why someone may want to edit code without the server running, so we want to avoid over-notifying. In this PR, we are changing the behaviour so that we output a notice in the logs, rather than showing an error dialog.

We should also update the README to explain how some features only available if the server is running, but since there is only currently one feature (Hover), it probably makes more sense to do that after Code Lens is added in https://github.com/Shopify/ruby-lsp-rails/pull/67.

Paired on with @vinistock 