### PR TITLE
Move to earlier in Rack middleware

### DIFF
--- a/lib/ruby_lsp_rails/railtie.rb
+++ b/lib/ruby_lsp_rails/railtie.rb
@@ -8,7 +8,7 @@ module RubyLsp
   module Rails
     class Railtie < ::Rails::Railtie
       initializer "ruby_lsp_rails.setup" do |app|
-        app.config.middleware.insert_after(ActionDispatch::ShowExceptions, RubyLsp::Rails::Middleware)
+        app.config.middleware.insert_before(ActionDispatch::Static, RubyLsp::Rails::Middleware)
 
         config.after_initialize do |_app|
           if defined?(::Rails::Server)


### PR DESCRIPTION
Some applications may add custom middleware for processing requests, and the requests generated by ruby-lsp-rails may not match the expected structure, causing warnings or errors. (We were seeing this happen in Core).

By moving the middleware to earlier in the Rack middleware stack, we can prevent this.

There are a number of options for where we could have put this relevative to other middlewares - we went with `ActionDispatch::Static` as it is handled early in the request processing, and it is commonly used so unlikely to be removed.

We observed an additional benefit of a performance improvement since this is now handled before most of the Rails request processing.

Co-authored with @vinistock 