### PR TITLE
Use a Rack app instead of Rails middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,22 @@ Ruby LSP Rails is a [Ruby LSP](https://github.com/Shopify/ruby-lsp) extension fo
 To install, add the following line to your application's Gemfile:
 
 ```ruby
+# Gemfile
 group :development do
   gem "ruby-lsp-rails"
+end
+```
+Some features rely on server introspection, and use a Rack server which is automatically mounted by using a Railtie.
+
+For applications with specialized routing requirements, such as custom sharding, this may not be compatible. It can
+be disabled with:
+
+```ruby
+# config/environments/development.rb
+Rails.application.configure do
+  # ...
+  config.ruby_lsp_rails.server = false
+  # ...
 end
 ```
 
@@ -41,7 +55,7 @@ cause the test runner to hang.
 
 This gem consists of two components that enable enhanced Rails functionality in the editor:
 
-1. A Rack middleware that automatically exposes APIs when Rails server is running
+1. A Rack app that automatically exposes APIs when Rails server is running
 1. A Ruby LSP extension that connects to the exposed APIs to fetch runtime information from the Rails server
 
 This is why the Rails server needs to be running for some features to work.

--- a/lib/ruby_lsp_rails/rack_app.rb
+++ b/lib/ruby_lsp_rails/rack_app.rb
@@ -3,32 +3,26 @@
 
 module RubyLsp
   module Rails
-    class Middleware
+    class RackApp
       extend T::Sig
 
       BASE_PATH = "/ruby_lsp_rails/"
-
-      sig { params(app: T.untyped).void }
-      def initialize(app)
-        @app = app
-      end
 
       sig { params(env: T::Hash[T.untyped, T.untyped]).returns(T::Array[T.untyped]) }
       def call(env)
         request = ActionDispatch::Request.new(env)
         path = request.path
-        return @app.call(env) unless path.start_with?(BASE_PATH)
 
         route, argument = path.delete_prefix(BASE_PATH).split("/")
 
         case route
+        when "activate"
+          [200, { "Content-Type" => "application/json" }, []]
         when "models"
           resolve_database_info_from_model(argument)
         else
-          [200, { "Content-Type" => "text/plain" }, []]
+          not_found
         end
-      rescue
-        @app.call(env)
       end
 
       private

--- a/test/ruby_lsp_rails/rack_app_test.rb
+++ b/test/ruby_lsp_rails/rack_app_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 module RubyLsp
   module Rails
-    class ModelsControllerTest < ActionDispatch::IntegrationTest
+    class RackAppTest < ActionDispatch::IntegrationTest
       test "GET show returns column information for existing models" do
         get "/ruby_lsp_rails/models/User"
         assert_response(:success)


### PR DESCRIPTION
By using a Rack app instead of Rails Middleware, we don't need to worry about where to insert the middleware in the stack (https://github.com/Shopify/ruby-lsp-rails/pull/89).

Apps can opt of the app with `config.ruby_lsp_rails.server = false`, while still being able to take advantage of other features of the extension.

Tophatted against Code DB and Core (with the server disabled).

Co-authored with @vinistock 
