### PR TITLE
Bump upper bound for Ruby LSP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-lsp-rails (0.1.0)
       rails (>= 6.0)
-      ruby-lsp (>= 0.6.2, < 0.7.0)
+      ruby-lsp (>= 0.6.2, < 0.8.0)
       sorbet-runtime (>= 0.5.9897)
 
 GEM

--- a/ruby-lsp-rails.gemspec
+++ b/ruby-lsp-rails.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency("rails", ">= 6.0")
-  spec.add_dependency("ruby-lsp", ">= 0.6.2", "< 0.7.0")
+  spec.add_dependency("ruby-lsp", ">= 0.6.2", "< 0.8.0")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9897")
 end


### PR DESCRIPTION
In anticipation of https://github.com/Shopify/ruby-lsp/pull/789 being released as 0.7.x.