### PR TITLE
Fix Code Lens for test with empty string as name

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -61,6 +61,9 @@ module RubyLsp
         first_argument = node.arguments.parts.first
         return unless first_argument.is_a?(SyntaxTree::StringLiteral)
 
+        # The test name may be a blank string while the code is being typed
+        return if first_argument.parts.empty?
+
         test_name = first_argument.parts.first.value
         return unless test_name
 


### PR DESCRIPTION
The dashboard is showing some exceptions coming through for ruby-lsp-rails on Core. Although we are unable to see the exact code in use, I was able to reproduce with a test which has a blank string as the test name. If the Code Lens requests runs before the author has typed the test name then an exception occurs.