### PR TITLE
Fix Code Lens heredoc handling

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -64,6 +64,9 @@ module RubyLsp
         # The test name may be a blank string while the code is being typed
         return if first_argument.parts.empty?
 
+        # We can't handle interpolation yet
+        return unless first_argument.parts.all? { |part| part.is_a?(SyntaxTree::TStringContent) }
+
         test_name = first_argument.parts.first.value
         return unless test_name
 


### PR DESCRIPTION
We haven't yet decided how to handle interpolation within test case names so we'll ignore them for now.