### PR TITLE
Fail gracefully on connect and timeout errors

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_client.rb
@@ -48,14 +48,14 @@ module RubyLsp
         return unless response.code == "200"
 
         JSON.parse(response.body.chomp, symbolize_names: true)
-      rescue Errno::ECONNREFUSED, ServerAddressUnknown
+      rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Net::ReadTimeout, ServerAddressUnknown
         nil
       end
 
       sig { void }
       def check_if_server_is_running!
         request("activate", 0.2)
-      rescue Errno::ECONNREFUSED, ServerAddressUnknown
+      rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, ServerAddressUnknown
         warn(SERVER_NOT_RUNNING_MESSAGE)
       rescue Net::ReadTimeout
         # If the server is running, but the initial request is taking too long, we don't want to block the

--- a/test/ruby_lsp_rails/rails_client_test.rb
+++ b/test/ruby_lsp_rails/rails_client_test.rb
@@ -22,6 +22,18 @@ module RubyLsp
         assert_equal(expected_response, RailsClient.instance.model("User"))
       end
 
+      test "model returns nil when failing to open TCP connections" do
+        Net::HTTP.any_instance.expects(:get).raises(Errno::EADDRNOTAVAIL)
+
+        assert_nil(RailsClient.instance.model("User"))
+      end
+
+      test "model returns nil when requests timeout" do
+        Net::HTTP.any_instance.expects(:get).raises(Net::ReadTimeout)
+
+        assert_nil(RailsClient.instance.model("User"))
+      end
+
       test "instantiation finds the right directory when bundle gemfile points to .ruby-lsp" do
         previous_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
         project_root = Pathname.new(previous_bundle_gemfile).dirname
@@ -37,8 +49,16 @@ module RubyLsp
         ENV["BUNDLE_GEMFILE"] = previous_bundle_gemfile
       end
 
-      test "check_if_server_is_running! raises if no server is found" do
+      test "check_if_server_is_running! warns if no server is found" do
         Net::HTTP.any_instance.expects(:get).raises(Errno::ECONNREFUSED)
+
+        assert_output("", RailsClient::SERVER_NOT_RUNNING_MESSAGE + "\n") do
+          RailsClient.instance.check_if_server_is_running!
+        end
+      end
+
+      test "check_if_server_is_running! warns if connection fails" do
+        Net::HTTP.any_instance.expects(:get).raises(Errno::EADDRNOTAVAIL)
 
         assert_output("", RailsClient::SERVER_NOT_RUNNING_MESSAGE + "\n") do
           RailsClient.instance.check_if_server_is_running!


### PR DESCRIPTION
We need to fail gracefully if opening the TCP connection fails. Also, when searching for models, we need to handle timeouts gracefully.