### PR TITLE
Support escaped multiline strings in test names

### DIFF
--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -38,6 +38,30 @@ module RubyLsp
         assert_match("Debug", response[5].command.title)
       end
 
+      test "recognizes multiline escaped strings" do
+        @store.set(uri: "file:///fake.rb", source: <<~RUBY, version: 1)
+          class Test < ActiveSupport::TestCase
+            test "an example" \
+              "multiline" do
+              # test body
+            end
+          end
+        RUBY
+
+        response = RubyLsp::Executor.new(@store, @message_queue).execute({
+          method: "textDocument/codeLens",
+          params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 0, character: 0 } },
+        }).response
+
+        # The first 3 responses are for the test class.
+        # The last 3 are for the test declaration.
+        assert_equal(6, response.size)
+        assert_match("Run", response[3].command.title)
+        assert_equal("bin/rails test /fake.rb:2", response[3].command.arguments[2])
+        assert_match("Run In Terminal", response[4].command.title)
+        assert_match("Debug", response[5].command.title)
+      end
+
       test "ignores unnamed tests (empty string)" do
         @store.set(uri: "file:///fake.rb", source: <<~RUBY, version: 1)
           class Test < ActiveSupport::TestCase


### PR DESCRIPTION
Closes #103

I added support only for two lines. If we were to support any number of concatenations, we'd need to use a loop that keeps checking if the `right` side of the concatenation is another concatenation, which I think is not worth the complexity. Supporting one concatenation will be enough for the majority of cases.