### PR TITLE
Move listener registration to the extension activation

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -39,8 +39,6 @@ module RubyLsp
       ResponseType = type_member { { fixed: T::Array[::RubyLsp::Interface::CodeLens] } }
       BASE_COMMAND = "bin/rails test"
 
-      ::RubyLsp::Requests::CodeLens.add_listener(self)
-
       sig { override.returns(ResponseType) }
       attr_reader :response
 

--- a/lib/ruby_lsp/ruby_lsp_rails/extension.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/extension.rb
@@ -14,6 +14,9 @@ module RubyLsp
 
       sig { override.void }
       def activate
+        ::RubyLsp::Requests::Hover.add_listener(RubyLsp::Rails::Hover)
+        ::RubyLsp::Requests::CodeLens.add_listener(RubyLsp::Rails::CodeLens)
+
         RubyLsp::Rails::RailsClient.instance.check_if_server_is_running!
       end
 

--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -20,8 +20,6 @@ module RubyLsp
 
       ResponseType = type_member { { fixed: T.nilable(::RubyLsp::Interface::Hover) } }
 
-      ::RubyLsp::Requests::Hover.add_listener(self)
-
       sig { override.returns(ResponseType) }
       attr_reader :response
 

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -7,11 +7,13 @@ module RubyLsp
   module Rails
     class CodeLensTest < ActiveSupport::TestCase
       setup do
+        ::RubyLsp::Requests::CodeLens.add_listener(RubyLsp::Rails::CodeLens)
         @message_queue = Thread::Queue.new
         @store = RubyLsp::Store.new
       end
 
       def teardown
+        ::RubyLsp::Requests::CodeLens.listeners.clear
         T.must(@message_queue).close
       end
 

--- a/test/ruby_lsp_rails/extension_test.rb
+++ b/test/ruby_lsp_rails/extension_test.rb
@@ -17,6 +17,9 @@ module RubyLsp
         RubyLsp::Rails::RailsClient.stubs(instance: rails_client)
         extension = Extension.new
         assert_predicate(extension, :activate)
+      ensure
+        ::RubyLsp::Requests::Hover.listeners.clear
+        ::RubyLsp::Requests::CodeLens.listeners.clear
       end
     end
   end


### PR DESCRIPTION
Related to https://github.com/Shopify/ruby-lsp/pull/813

We need to set a standard for registering feature enhancements always inside of `activate` or else disabling extensions becomes significantly more difficult.

This just moves our registrations there.