### PR TITLE
Improve development setup

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: ruby-lsp-rails
 type: ruby
 
 up:
-  - ruby: '3.2.1'
+  - ruby: '3.2.2'
   - bundler:
       gemfile: Gemfile
 

--- a/lib/ruby_lsp_rails/railtie.rb
+++ b/lib/ruby_lsp_rails/railtie.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "rails/railtie"
+require "rails"
 require "ruby_lsp_rails/rack_app"
 
 module RubyLsp


### PR DESCRIPTION
1. We should use Ruby 3.2.2 for development.
2. Instead of requiring `rails/railtie`, which is not a valid entry point, we should just require `rails`.
    - This is not an issue for our users, but it crashes `tapioca gem` because `rails/railtie` doesn't require sufficient dependencies.