### PR TITLE
Remove Gemfile.lock when running CI on Ruby 3.1 Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Remove Gemfile.lock
+        if: matrix.os == 'windows-latest' && matrix.ruby == '3.1'
+        run: rm Gemfile.lock
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
It has proved impossible to get CI to work without removing the Gemfile.lock. Let's remove it only for Ruby 3.1 on Windows, so that our auto-merge continues to work.