### PR TITLE
Improve README about NOTEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ See the [documentation](https://shopify.github.io/ruby-lsp-rails) for more in-de
 1. Open a test which inherits from `ActiveSupport::TestCase` or one of its descendants, such as `ActionDispatch::IntegrationTest`.
 2. Click on the "Run", "Run in Terminal" or "Debug" code lens which appears above the test class, or an individual test.
 
-Note: When using the Test Explorer view, if your code contains a statement to pause execution (e.g. `debugger`) it will
-cause the test runner to hang.
+> [!NOTE]
+> When using the Test Explorer view, if your code contains a statement to pause execution (e.g. `debugger`) it will
+> cause the test runner to hang.
 
 ## How It Works
 
@@ -60,8 +61,7 @@ This gem consists of two components that enable enhanced Rails functionality in 
 
 This is why the Rails server needs to be running for some features to work.
 
-> **Note**
->
+> [!NOTE]
 > There is no need to restart the Ruby LSP every time the Rails server is booted.
 > If the server is shut down, the extra features will temporarily disappear and reappear once the server is running again.
 


### PR DESCRIPTION
This is a small improvement to README.

It would be a little easier to read if the notes were in a consistent format. How about trying alerts syntax on GitHub?

- https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/
- https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

This results in the following display:

![image](https://github.com/Shopify/ruby-lsp-rails/assets/111689/15bf6a55-f2b4-4b43-86ed-97a015fd2ff0)
