### PR TITLE
Upgrade Ruby to 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
         include:
           - ruby: "head"
             experimental: true
@@ -28,7 +28,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          cache-version: 5
+          cache-version: 6
 
       - name: Check if documentation is up to date
         run: bundle exec rake ruby_lsp:check_docs

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
 
       - name: Configure git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,13 +160,13 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.9)
-    nokogiri (1.15.4-arm64-darwin)
+    nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x64-mingw-ucrt)
+    nokogiri (1.16.0-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-darwin)
+    nokogiri (1.16.0-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
@@ -245,10 +245,10 @@ GEM
       sorbet-static-and-runtime (>= 0.5.10187)
       syntax_tree (>= 6.1.1)
       thor (>= 0.19.2)
-    sqlite3 (1.6.8-arm64-darwin)
-    sqlite3 (1.6.8-x64-mingw-ucrt)
-    sqlite3 (1.6.8-x86_64-darwin)
-    sqlite3 (1.6.8-x86_64-linux)
+    sqlite3 (1.7.0-arm64-darwin)
+    sqlite3 (1.7.0-x64-mingw-ucrt)
+    sqlite3 (1.7.0-x86_64-darwin)
+    sqlite3 (1.7.0-x86_64-linux)
     stringio (3.0.9)
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
@@ -280,8 +280,8 @@ GEM
 
 PLATFORMS
   arm64-darwin
-  x64-mingw-ucrt
   x64-mingw32
+  x64-mingw-ucrt
   x86_64-darwin
   x86_64-linux
 

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: ruby-lsp-rails
 type: ruby
 
 up:
-  - ruby: '3.2.2'
+  - ruby: '3.3.0'
   - bundler:
       gemfile: Gemfile
 


### PR DESCRIPTION
Start using Ruby 3.3 for development/CI.