### PR TITLE
Prototype LSP Rails runner

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -43,7 +43,6 @@ module RubyLsp
 
       def send_request(request, params = nil)
         hash = {
-          id: rand(100),
           method: request,
         }
 

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -6,6 +6,7 @@ require "ruby_lsp/addon"
 require_relative "rails_client"
 require_relative "hover"
 require_relative "code_lens"
+require "open3"
 
 module RubyLsp
   module Rails
@@ -20,10 +21,52 @@ module RubyLsp
       sig { override.params(message_queue: Thread::Queue).void }
       def activate(message_queue)
         client.check_if_server_is_running!
+        @stdin, @stdout, @stderr, @wait_thread = Open3.popen3("bin/rails runner lib/ruby_lsp/ruby_lsp_rails/server.rb")
+
+        @stdin.binmode
+        @stdout.binmode
       end
 
       sig { override.void }
-      def deactivate; end
+      def deactivate
+        make_request("shutdown")
+
+        @stdin.close
+        @stdout.close
+        @stderr.close
+      end
+
+      def make_request(request, params = nil)
+        send_request(request, params)
+        read_response(request)
+      end
+
+      def send_request(request, params = nil)
+        hash = {
+          id: rand(100),
+          method: request,
+        }
+
+        hash[:params] = params if params
+        json = hash.to_json
+        @stdin.write("Content-Length: #{json.length}\r\n\r\n")
+        @stdin.write(json)
+      end
+
+      def read_response(request)
+        Timeout.timeout(5) do
+          # Read headers until line breaks
+          headers = @stdout.gets("\r\n\r\n")
+
+          # Read the response content based on the length received in the headers
+          raw_response = @stdout.read(headers[/Content-Length: (\d+)/i, 1].to_i)
+
+          json = JSON.parse(raw_response, symbolize_names: true)
+          warn("*** response ***: #{json}")
+        end
+      rescue Timeout::Error
+        raise "Request #{request} timed out. Is the request returning a response?"
+      end
 
       # Creates a new CodeLens listener. This method is invoked on every CodeLens request
       sig do

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -21,7 +21,7 @@ module RubyLsp
       sig { override.params(message_queue: Thread::Queue).void }
       def activate(message_queue)
         client.check_if_server_is_running!
-        @stdin, @stdout, @stderr, @wait_thread = Open3.popen3("bin/rails runner lib/ruby_lsp/ruby_lsp_rails/server.rb")
+        @stdin, @stdout, @stderr, @wait_thread = Open3.popen3("bin/rails runner #{__dir__}/server.rb")
 
         @stdin.binmode
         @stdout.binmode

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -29,7 +29,7 @@ module RubyLsp
 
       sig { override.void }
       def deactivate
-        make_request("shutdown")
+        send_request("shutdown")
 
         @stdin.close
         @stdout.close

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -48,8 +48,7 @@ module RubyLsp
 
         hash[:params] = params if params
         json = hash.to_json
-        @stdin.write("Content-Length: #{json.length}\r\n\r\n")
-        @stdin.write(json)
+        @stdin.write("Content-Length: #{json.length}\r\n\r\n", json)
       end
 
       def read_response(request)

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -21,7 +21,7 @@ module RubyLsp
       sig { override.params(message_queue: Thread::Queue).void }
       def activate(message_queue)
         client.check_if_server_is_running!
-        @stdin, @stdout, @stderr, @wait_thread = Open3.popen3("bin/rails runner #{__dir__}/server.rb")
+        @stdin, @stdout, @stderr, @wait_thread = Open3.popen3("bin/rails", "runner", "#{__dir__}/server.rb")
 
         @stdin.binmode
         @stdout.binmode

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -18,9 +18,10 @@ while running
 
   response_json = nil
   case request_method
-  when "shutdown"
-    # returning the column names just to illustrate we have access the Rails app
+  when "schema"
     response_json = { result: "ok", columns: User.column_names }.to_json
+  when "shutdown"
+    response_json = { result: "ok" }.to_json
 
     running = false
   end

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -1,0 +1,30 @@
+# typed: false
+# frozen_string_literal: true
+
+require "json"
+
+running = true
+while running
+  # Read headers until line breaks
+  headers = $stdin.gets("\r\n\r\n")
+
+  # Read the response content based on the length received in the headers
+  request = $stdin.read(headers[/Content-Length: (\d+)/i, 1].to_i)
+
+  json = JSON.parse(request, symbolize_names: true)
+
+  request_method = json.fetch(:method)
+  params = json[:params]
+
+  response_json = nil
+  case request_method
+  when "shutdown"
+    # returning the column names just to illustrate we have access the Rails app
+    response_json = { result: "ok", columns: User.column_names }.to_json
+
+    running = false
+  end
+
+  $stdout.write("Content-Length: #{response_json.length}\r\n\r\n")
+  $stdout.write(response_json)
+end


### PR DESCRIPTION
Currently with ruby-lsp-rails, the Rails server needs to be running so that the LSP can make requests to it, since requests are sent over HTTP.

This PR demonstrate a different approach we are considering. The LSP gem will spawn a separate Rails instance, and we will use stdin/stdout for communication. For prototyping purposes, we are using `rails runner`, but for a real implementation this could be a new Rails command, such as `rails lsp`.

The LSP gem will also be responsible for shutting down the server. (The example here currently implements that command only.)

The protocol will be similar to [that of the LSP protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification) – content-length header, followed by two newlines, then a JSON structure.

Since we control both sides of the protocol, we can change it as needed, so we don't need to be too concerned about the structure.

We're looking for general feedback on:

- Does this approach make sense overall?
- Is there any functionality that would become impossible without being embedded in the Rails server?
- Are there any other gotchas we need to be aware of early on?