### PR TITLE
Revert unnecessary bundler cache version change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           bundler: latest
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          cache-version: ${{ matrix.os }}-ruby-${{ matrix.ruby }}-0
+          cache-version: 7
 
       - name: Check if documentation is up to date
         run: bundle exec rake ruby_lsp:check_docs


### PR DESCRIPTION
It was a debugging commit in #232 that's merged by accident.