### PR TITLE
Only generate app_uri.txt and append Rack app when the server feature is enabled

### DIFF
--- a/lib/ruby_lsp_rails/railtie.rb
+++ b/lib/ruby_lsp_rails/railtie.rb
@@ -12,15 +12,13 @@ module RubyLsp
 
       initializer "ruby_lsp_rails.setup" do |_app|
         config.after_initialize do |app|
-          unless config.ruby_lsp_rails.server == false
+          # If we start the app with `bin/rails console` then `Rails::Server` is not defined.
+          if defined?(::Rails::Server) && config.ruby_lsp_rails.server
             app.routes.prepend do
               T.bind(self, ActionDispatch::Routing::Mapper)
               mount(RackApp.new => RackApp::BASE_PATH)
             end
-          end
 
-          # If we start the app with `bin/rails console` then `Rails::Server` is not defined.
-          if defined?(::Rails::Server)
             ssl_enable, host, port = ::Rails::Server::Options.new.parse!(ARGV).values_at(:SSLEnable, :Host, :Port)
             app_uri = "#{ssl_enable ? "https" : "http"}://#{host}:#{port}"
             app_uri_path = ::Rails.root.join("tmp", "app_uri.txt")


### PR DESCRIPTION
Because the addon client uses the `tmp/app_uri.txt`'s existence to determine whether to send the request, if the file is generated when the server feature is disabled, the client would just spam the server with requests.

We also don't need to append the Rack app if Rails server is not invoked.