### PR TITLE
Don't mount rack app at application level

### DIFF
--- a/lib/ruby_lsp_rails/rack_app.rb
+++ b/lib/ruby_lsp_rails/rack_app.rb
@@ -8,10 +8,17 @@ module RubyLsp
 
       BASE_PATH = "/ruby_lsp_rails/"
 
+      sig { params(app: T.untyped).void }
+      def initialize(app)
+        @app = T.let(app, T.untyped)
+      end
+
       sig { params(env: T::Hash[T.untyped, T.untyped]).returns(T::Array[T.untyped]) }
       def call(env)
         request = ActionDispatch::Request.new(env)
         path = request.path
+
+        return @app.call(env) unless path.starts_with?(BASE_PATH)
 
         route, argument = path.delete_prefix(BASE_PATH).split("/")
 

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/ruby_lsp_rails/rack_app_test.rb
+++ b/test/ruby_lsp_rails/rack_app_test.rb
@@ -39,6 +39,19 @@ module RubyLsp
         get "/ruby_lsp_rails/activate"
         assert_response(:success)
       end
+
+      test "middleware is inserted after Rails::Rack::Logger" do
+        logger_index = ::Rails.configuration.middleware.middlewares.index(::Rails::Rack::Logger)
+        lsp_index = ::Rails.configuration.middleware.middlewares.index(RackApp)
+
+        assert_operator(logger_index, :<, lsp_index)
+      end
+
+      test "middleware forwards non-lsp requests to rails app" do
+        assert_raises(ActionController::RoutingError) do
+          get "/unrecognized_application_route"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Don't mount rack app at application level

This causes Rails middleware like `ActiveRecord::Migration::CheckPending` to get in the way of LSP requests. If we could surface migration issues somewhere else using the LSP, that would be nice.

Currently, if you generate a migration on a project using the LSP, you get this error on hovering over a model:

```
Started GET "/ruby_lsp_rails/models/Article" for ::1 at 2024-01-31 11:25:32 -0600
  ActiveRecord::SchemaMigration Load (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC

ActiveRecord::PendingMigrationError (

Migrations are pending. To resolve this issue, run:

        bin/rails db:migrate

You have 1 pending migration:

db/migrate/20240131171953_add_a_to_b.rb


):

activerecord (7.1.3) lib/active_record/migration.rb:755:in `check_pending_migrations'
activerecord (7.1.3) lib/active_record/migration.rb:644:in `block (2 levels) in call'
activesupport (7.1.3) lib/active_support/file_update_checker.rb:85:in `execute'
activesupport (7.1.3) lib/active_support/file_update_checker.rb:95:in `execute_if_updated'
...
```