### PR TITLE
Add code lens for running migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Ruby LSP Rails is a [Ruby LSP](https://github.com/Shopify/ruby-lsp) addon for ex
 * Navigate to associations, validations, callbacks and test cases using your editor's "Go to Symbol" feature, or outline view.
 * Jump to the definition of callbacks using your editor's "Go to Definition" feature.
 * Jump to the declaration of a route.
+* Code Lens allowing fast-forwarding or rewinding of migrations.
 
 ## Installation
 


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp-rails/issues/51

Adds code lens to run migrations to specific versions in the terminal. This is convenient because it allows developers to quickly rollback or fast-forward to specific schema versions with a click.

<img width="575" alt="Screenshot 2024-01-31 at 9 09 05 PM" src="https://github.com/Shopify/ruby-lsp-rails/assets/5162312/3cabbd56-16c6-4609-b4fb-55b65698115a">
<img width="787" alt="Screenshot 2024-01-31 at 9 10 45 PM" src="https://github.com/Shopify/ruby-lsp-rails/assets/5162312/f5ea492b-8f33-4228-8330-5f3a4f7cefdc">
