### PR TITLE
Add code lens for mapping actions to routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Ruby LSP Rails is a [Ruby LSP](https://github.com/Shopify/ruby-lsp) addon for ex
 * Jump to the definition of callbacks using your editor's "Go to Definition" feature.
 * Jump to the declaration of a route.
 * Code Lens allowing fast-forwarding or rewinding of migrations.
+* Code Lens showing the path that a route action corresponds to.
 
 ## Installation
 

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -53,7 +53,7 @@ module RubyLsp
       def create_code_lens_listener(response_builder, uri, dispatcher)
         return unless T.must(@global_state).test_library == "rails"
 
-        CodeLens.new(response_builder, uri, dispatcher)
+        CodeLens.new(@client, response_builder, uri, dispatcher)
       end
 
       sig do

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -122,6 +122,14 @@ module RubyLsp
         nil
       end
 
+      sig { params(controller: String, action: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      def route(controller:, action:)
+        make_request("route_info", controller: controller, action: action)
+      rescue IncompleteMessageError
+        $stderr.puts("Ruby LSP Rails failed to get route information: #{@stderr.read}")
+        nil
+      end
+
       sig { void }
       def trigger_reload
         $stderr.puts("Reloading Rails application")

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  def index; end
+
+  def archive; end
+end

--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -122,4 +122,16 @@ class ServerTest < ActiveSupport::TestCase
     response = @server.execute("route_location", { name: "invalid_path" })
     assert_nil response[:result]
   end
+
+  test "route info" do
+    response = @server.execute("route_info", { controller: "UsersController", action: "index" })
+
+    result = response[:result]
+
+    source_location_path, source_location_line = result[:source_location]
+    assert_equal "4", source_location_line
+    assert source_location_path.end_with?("config/routes.rb")
+    assert_equal "GET", result[:verb]
+    assert_equal "/users(.:format)", result[:path]
+  end
 end


### PR DESCRIPTION
Part of  https://github.com/Shopify/ruby-lsp-rails/issues/50

Adds code lens to find routes in the routes file based on a given controller action. You need to grep bin/rails routes for this information manually. If Rails already knows this info, we should make it more easily accessible.

<img width="675" alt="Screenshot 2024-02-02 at 3 53 58 PM" src="https://github.com/Shopify/ruby-lsp-rails/assets/5162312/3792efad-fb67-4419-b538-cfde9b35ad85">
