### PR TITLE
Fixes stdout leak in tests

### DIFF
--- a/test/ruby_lsp_rails/addon_test.rb
+++ b/test/ruby_lsp_rails/addon_test.rb
@@ -15,9 +15,11 @@ module RubyLsp
         rails_client = stub("rails_client", check_if_server_is_running!: true)
 
         RubyLsp::Rails::RailsClient.stubs(instance: rails_client)
+
         addon = Addon.new
         queue = Thread::Queue.new
-        assert(addon.activate(queue))
+
+        capture_io { assert(addon.activate(queue)) }
       ensure
         T.must(queue).close
       end


### PR DESCRIPTION
Before
```
Run options: --seed 40302

# Running:

..........Rails server is not running. To get Rails features in the editor, boot the Rails server
...........................

Finished in 0.654810s, 56.5049 runs/s, 241.2914 assertions/s.
```

After
```
Run options: --seed 31481

# Running:

...............................

Finished in 0.664854s, 46.6268 runs/s, 206.0603 assertions/s.
```