### PR TITLE
Avoid inspecting schema info for abstract classes

### DIFF
--- a/lib/ruby_lsp_rails/rack_app.rb
+++ b/lib/ruby_lsp_rails/rack_app.rb
@@ -31,7 +31,7 @@ module RubyLsp
       def resolve_database_info_from_model(model_name)
         const = ActiveSupport::Inflector.safe_constantize(model_name)
 
-        if const && const < ActiveRecord::Base
+        if const && const < ActiveRecord::Base && !const.abstract_class?
           begin
             schema_file = ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(const.connection.pool.db_config)
           rescue => e

--- a/test/ruby_lsp_rails/rack_app_test.rb
+++ b/test/ruby_lsp_rails/rack_app_test.rb
@@ -35,6 +35,11 @@ module RubyLsp
         assert_response(:not_found)
       end
 
+      test "GET show returns not_found if class is an abstract model" do
+        get "/ruby_lsp_rails/models/ApplicationRecord"
+        assert_response(:not_found)
+      end
+
       test "GET activate returns success to display that server is running" do
         get "/ruby_lsp_rails/activate"
         assert_response(:success)


### PR DESCRIPTION
Hovering on model classes like `ApplicationRecord` in a Rails application results
in raising an `ActiveRecord::TableNotSpecifiedError,` which we should be
accounting for.

Before:
```
Started GET "/ruby_lsp_rails/models/ApplicationRecord" for ::1 at 2024-02-03 08:15:12 -0600

ActiveRecord::TableNotSpecified (ApplicationRecord has no table configured. Set one with ApplicationRecord.table_name=):
...
```

After:
```
Started GET "/ruby_lsp_rails/models/ApplicationRecord" for ::1 at 2024-02-03 08:17:35 -0600
```