### PR TITLE
Update Hover and CodeLens as per refactored responses in Ruby LSP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 6.0)
       activerecord (>= 6.0)
       railties (>= 6.0)
-      ruby-lsp (>= 0.13.0, < 0.14.0)
+      ruby-lsp (>= 0.14.0, < 0.15.0)
       sorbet-runtime (>= 0.5.9897)
 
 GEM
@@ -221,9 +221,9 @@ GEM
       rubocop (~> 1.51)
     rubocop-sorbet (0.7.6)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.13.4)
+    ruby-lsp (0.14.0)
       language_server-protocol (~> 3.17.0)
-      prism (>= 0.19.0, < 0.20)
+      prism (>= 0.19.0, < 0.22)
       sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -28,23 +28,25 @@ module RubyLsp
       # Creates a new CodeLens listener. This method is invoked on every CodeLens request
       sig do
         override.params(
+          response_builder: ResponseBuilders::CollectionResponseBuilder[Interface::CodeLens],
           uri: URI::Generic,
           dispatcher: Prism::Dispatcher,
-        ).returns(T.nilable(Listener[T::Array[Interface::CodeLens]]))
+        ).void
       end
-      def create_code_lens_listener(uri, dispatcher)
-        CodeLens.new(uri, dispatcher)
+      def create_code_lens_listener(response_builder, uri, dispatcher)
+        CodeLens.new(response_builder, uri, dispatcher)
       end
 
       sig do
         override.params(
+          response_builder: ResponseBuilders::Hover,
           nesting: T::Array[String],
           index: RubyIndexer::Index,
           dispatcher: Prism::Dispatcher,
-        ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
+        ).void
       end
-      def create_hover_listener(nesting, index, dispatcher)
-        Hover.new(client, nesting, index, dispatcher)
+      def create_hover_listener(response_builder, nesting, index, dispatcher)
+        Hover.new(client, response_builder, nesting, index, dispatcher)
       end
 
       sig { override.returns(String) }

--- a/ruby-lsp-rails.gemspec
+++ b/ruby-lsp-rails.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("actionpack", ">= 6.0")
   spec.add_dependency("activerecord", ">= 6.0")
   spec.add_dependency("railties", ">= 6.0")
-  spec.add_dependency("ruby-lsp", ">= 0.13.0", "< 0.14.0")
+  spec.add_dependency("ruby-lsp", ">= 0.14.0", "< 0.15.0")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9897")
 end

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -44,16 +44,14 @@ module RubyLsp
           User
         RUBY
 
-        assert_equal(<<~CONTENT, response.contents.value)
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
           ```ruby
           User
           ```
 
           **Definitions**: [fake.rb](file:///fake.rb#L1,1-2,4)
-
-
-
           [Schema](file://#{@client.root}/db/schema.rb)
+
 
           **id**: integer
 
@@ -94,7 +92,7 @@ module RubyLsp
           Blog::User
         RUBY
 
-        assert_equal(<<~CONTENT, response.contents.value)
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
           [Schema](file://#{@client.root}/db/schema.rb)
 
           **id**: integer


### PR DESCRIPTION
Based on Ruby LSP version 0.14.0, we need to update the `Hover` and `CodeLens` implementations in the Rails add-on.

These no longer extend the `Listener` class, and now use the response builder.

The associated tests have been updated, and these changes have been tested locally.