### PR TITLE
Add code lens support for rails active support test cases using `minitest/spec`

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -57,7 +57,7 @@ module RubyLsp
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
         message_value = node.message
-        return unless message_value == "test"
+        return unless message_value == "test" || message_value == "it"
 
         arguments = node.arguments&.arguments
         return unless arguments&.any?

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -32,6 +32,24 @@ module RubyLsp
         assert_match("Debug", response[5].command.title)
       end
 
+      test "recognizes Rails Active Support test cases using minitest/spec" do
+        response = generate_code_lens_for_source(<<~RUBY)
+          class Test < ActiveSupport::TestCase
+            it "an example" do
+              # test body
+            end
+          end
+        RUBY
+
+        # The first 3 responses are for the test class.
+        # The last 3 are for the test declaration.
+        assert_equal(6, response.size)
+        assert_match("Run", response[3].command.title)
+        assert_equal("bin/rails test /fake.rb:2", response[3].command.arguments[2])
+        assert_match("Run In Terminal", response[4].command.title)
+        assert_match("Debug", response[5].command.title)
+      end
+
       test "recognizes multiline escaped strings" do
         response = generate_code_lens_for_source(<<~RUBY)
           class Test < ActiveSupport::TestCase


### PR DESCRIPTION
Hello 👋

This is introducing code lens support for [minitest/spec](https://github.com/minitest/minitest?tab=readme-ov-file#specs-)

<img width="584" alt="image" src="https://github.com/Shopify/ruby-lsp-rails/assets/12185788/0aa8ab9c-ebaf-45a7-8d90-98ff865ac090">
