### PR TITLE
Handle apps without ActiveRecord

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -29,7 +29,7 @@ module RubyLsp
       sig { params(model_name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
       def resolve_database_info_from_model(model_name)
         const = ActiveSupport::Inflector.safe_constantize(model_name)
-        unless const && const < ActiveRecord::Base && !const.abstract_class?
+        unless const && defined?(ActiveRecord) && const < ActiveRecord::Base && !const.abstract_class?
           return {
             result: nil,
           }


### PR DESCRIPTION
Fixes #262

I tried to add a test which undefines `ActiveRecord`:

```ruby
      test "#model returns nil if app doesn't use ActiveRecord" do
        Temporary = ActiveRecord
        Object.send(:remove_const, :ActiveRecord)
        assert_nil(@client.model("User"))
      ensure
        ActiveRecord = Temporary
      end
```

but it fails because of the ActiveSupport internals:

```
/Users/andyw8/.gem/ruby/3.2.1/gems/activerecord-7.1.3/lib/active_record/query_cache.rb:35:in `complete': uninitialized constant ActiveRecord::QueryCache::ActiveRecord (NameError)

      ActiveRecord::Base.connection_handler.each_connection_pool do |pool|
                  ^^^^^^
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/execution_wrapper.rb:37:in `before'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:426:in `block in make_lambda'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:202:in `block (2 levels) in halting'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:707:in `block (2 levels) in default_terminator'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:706:in `catch'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:706:in `block in default_terminator'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:203:in `block in halting'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:598:in `block in invoke_before'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:598:in `each'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:598:in `invoke_before'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/callbacks.rb:109:in `run_callbacks'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/execution_wrapper.rb:143:in `complete'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/execution_wrapper.rb:107:in `perform'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/activesupport-7.1.3/lib/active_support/executor/test_helper.rb:5:in `run'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:1126:in `run_one_method'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:378:in `run_one_method'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:365:in `block (2 levels) in run'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:364:in `each'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:364:in `block in run'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:412:in `on_signal'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:399:in `with_info_handler'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:363:in `run'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/railties-7.1.3/lib/rails/test_unit/line_filtering.rb:10:in `run'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:185:in `block in __run'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:185:in `map'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:185:in `__run'
        from /Users/andyw8/.gem/ruby/3.2.1/gems/minitest-5.21.2/lib/minitest.rb:162:in `run'
```

