### PR TITLE
Fallback to `NullClient` if initializing server fails

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -18,7 +18,11 @@ module RubyLsp
       end
 
       sig { override.params(message_queue: Thread::Queue).void }
-      def activate(message_queue); end
+      def activate(message_queue)
+        # Eagerly initialize the client in a thread. This allows the indexing from the Ruby LSP to continue running even
+        # while we boot large Rails applications in the background
+        Thread.new { client }
+      end
 
       sig { override.void }
       def deactivate

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -14,7 +14,7 @@ module RubyLsp
 
       sig { returns(RunnerClient) }
       def client
-        @client ||= T.let(RunnerClient.new, T.nilable(RunnerClient))
+        @client ||= T.let(RunnerClient.create_client, T.nilable(RunnerClient))
       end
 
       sig { override.params(message_queue: Thread::Queue).void }

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -19,6 +19,9 @@ rescue
   nil
 end
 
+# NOTE: We should avoid printing to stderr since it causes problems. We never read the standard error pipe from the
+# client, so it will become full and eventually hang or crash. Instead, return a response with an `error` key.
+
 module RubyLsp
   module Rails
     class Server

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -29,6 +29,53 @@ module RubyLsp
 
       extend T::Sig
 
+      sig { void }
+      def initialize
+        $stdin.sync = true
+        $stdout.sync = true
+        @running = T.let(true, T::Boolean)
+      end
+
+      sig { void }
+      def start
+        initialize_result = { result: { message: "ok" } }.to_json
+        $stdout.write("Content-Length: #{initialize_result.length}\r\n\r\n#{initialize_result}")
+
+        while @running
+          headers = $stdin.gets("\r\n\r\n")
+          json = $stdin.read(headers[/Content-Length: (\d+)/i, 1].to_i)
+
+          request = JSON.parse(json, symbolize_names: true)
+          response = execute(request.fetch(:method), request[:params])
+          next if response == VOID
+
+          json_response = response.to_json
+          $stdout.write("Content-Length: #{json_response.length}\r\n\r\n#{json_response}")
+        end
+      end
+
+      sig do
+        params(
+          request: String,
+          params: T::Hash[Symbol, T.untyped],
+        ).returns(T.any(Object, T::Hash[Symbol, T.untyped]))
+      end
+      def execute(request, params = {})
+        case request
+        when "shutdown"
+          @running = false
+          VOID
+        when "model"
+          resolve_database_info_from_model(params.fetch(:name))
+        else
+          VOID
+        end
+      rescue => e
+        { error: e.full_message(highlight: false) }
+      end
+
+      private
+
       sig { params(model_name: String).returns(T::Hash[Symbol, T.untyped]) }
       def resolve_database_info_from_model(model_name)
         const = ActiveSupport::Inflector.safe_constantize(model_name)
@@ -51,41 +98,7 @@ module RubyLsp
         end
         info
       rescue => e
-        {
-          error: e.message,
-        }
-      end
-
-      sig { void }
-      def start
-        $stdin.sync = true
-        $stdout.sync = true
-
-        running = T.let(true, T::Boolean)
-
-        while running
-          headers = $stdin.gets("\r\n\r\n")
-          request = $stdin.read(headers[/Content-Length: (\d+)/i, 1].to_i)
-
-          json = JSON.parse(request, symbolize_names: true)
-          request_method = json.fetch(:method)
-          params = json[:params]
-
-          response = case request_method
-          when "shutdown"
-            running = false
-            VOID
-          when "model"
-            resolve_database_info_from_model(params.fetch(:name))
-          else
-            VOID
-          end
-
-          next if response == VOID
-
-          json_response = response.to_json
-          $stdout.write("Content-Length: #{json_response.length}\r\n\r\n#{json_response}")
-        end
+        { error: e.full_message(highlight: false) }
       end
     end
   end

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -194,18 +194,22 @@ module RubyLsp
         executor.instance_variable_get(:@index).index_single(
           RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source
         )
-        response = executor.execute(
-          {
-            method: "textDocument/hover",
-            params: {
-              textDocument: { uri: uri },
-              position: position,
-            },
-          },
-        )
 
-        assert_nil(response.error)
-        response.response
+        response = T.let(nil, T.nilable(RubyLsp::Result))
+        capture_io do
+          response = executor.execute(
+            {
+              method: "textDocument/hover",
+              params: {
+                textDocument: { uri: uri },
+                position: position,
+              },
+            },
+          )
+        end
+
+        assert_nil(T.must(response).error)
+        T.must(response).response
       end
 
       def dummy_root

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -8,7 +8,9 @@ module RubyLsp
   module Rails
     class RunnerClientTest < ActiveSupport::TestCase
       setup do
-        @client = T.let(RunnerClient.new, RunnerClient)
+        capture_io do
+          @client = T.let(RunnerClient.new, RunnerClient)
+        end
       end
 
       teardown do

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -36,6 +36,20 @@ module RubyLsp
       test "returns nil if the request returns a nil response" do
         assert_nil @client.model("ApplicationRecord") # ApplicationRecord is abstract
       end
+
+      test "failing to spawn server creates a null client" do
+        FileUtils.mv("bin/rails", "bin/rails_backup")
+
+        assert_output("", %r{No such file or directory - bin/rails}) do
+          client = RunnerClient.create_client
+
+          assert_instance_of(NullClient, client)
+          assert_nil(client.model("User"))
+          assert_predicate(client, :stopped?)
+        end
+      ensure
+        FileUtils.mv("bin/rails_backup", "bin/rails")
+      end
     end
   end
 end

--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -10,24 +10,24 @@ class ServerTest < ActiveSupport::TestCase
   end
 
   test "returns nil if model doesn't exist" do
-    response = @server.resolve_database_info_from_model("Foo")
+    response = @server.execute("model", { name: "Foo" })
     assert_nil(response.fetch(:result))
   end
 
   test "returns nil if class is not a model" do
-    response = @server.resolve_database_info_from_model("Time")
+    response = @server.execute("model", { name: "Time" })
     assert_nil(response.fetch(:result))
   end
 
   test "returns nil if class is an abstract model" do
-    response = @server.resolve_database_info_from_model("ApplicationRecord")
+    response = @server.execute("model", { name: "ApplicationRecord" })
     assert_nil(response.fetch(:result))
   end
 
   test "handles older Rails version which don't have `schema_dump_path`" do
     ActiveRecord::Tasks::DatabaseTasks.send(:alias_method, :old_schema_dump_path, :schema_dump_path)
     ActiveRecord::Tasks::DatabaseTasks.undef_method(:schema_dump_path)
-    response = @server.resolve_database_info_from_model("User")
+    response = @server.execute("model", { name: "User" })
     assert_nil(response.fetch(:result)[:schema_file])
   ensure
     ActiveRecord::Tasks::DatabaseTasks.send(:alias_method, :schema_dump_path, :old_schema_dump_path)


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp-rails/issues/265

Currently, if we fail to initialize the server, we show errors every time hover occurs. The reason is because `initialize` raises, meaning the [memoized client](https://github.com/Shopify/ruby-lsp-rails/blob/f32f92c1bbaccae6889c13706b5de0e651335097/lib/ruby_lsp/ruby_lsp_rails/addon.rb#L17) is never set and thus causing us to try to initialized it again on every hover.

Since the client is bound to be used everywhere in this addon, I think the easiest way of handling it is falling back to a `NullClient` that simply no-ops most operations. That way, we don't have to spread a bunch of conditionals everywhere in the code.

### Manual tests

1. On this branch, change the `Open3.popen3` command from `bin/rails` to something that doesn't exist. Like `non-existing-command-test`.
2. Reload VS Code
3. Try to hover on a constant
4. Verify that an error gets printed to the output tab
5. Hover again on a constant
6. Verify nothing gets printed