### PR TITLE
Ignore sorbet paths for the debugger

### DIFF
--- a/sorbet/rbi/shims/debug.rbi
+++ b/sorbet/rbi/shims/debug.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
+module DEBUGGER__
+  CONFIG = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,3 +12,8 @@ require "rails/test_help"
 require "mocha/minitest"
 require "ruby_lsp/internal"
 require "ruby_lsp/ruby_lsp_rails/addon"
+
+if defined?(DEBUGGER__)
+  DEBUGGER__::CONFIG[:skip_path] =
+    Array(DEBUGGER__::CONFIG[:skip_path]) + Gem.loaded_specs["sorbet-runtime"].full_require_paths
+end


### PR DESCRIPTION
So that the debugger doesn't stop in Sorbet frames.