### PR TITLE
Fix runner client race condition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 6.0)
       activerecord (>= 6.0)
       railties (>= 6.0)
-      ruby-lsp (>= 0.14.0, < 0.15.0)
+      ruby-lsp (>= 0.14.2, < 0.15.0)
       sorbet-runtime (>= 0.5.9897)
 
 GEM
@@ -221,7 +221,7 @@ GEM
       rubocop (~> 1.51)
     rubocop-sorbet (0.7.7)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.14.1)
+    ruby-lsp (0.14.2)
       language_server-protocol (~> 3.17.0)
       prism (>= 0.22.0, < 0.25)
       sorbet-runtime (>= 0.5.10782)

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -12,21 +12,24 @@ module RubyLsp
     class Addon < ::RubyLsp::Addon
       extend T::Sig
 
-      sig { returns(RunnerClient) }
-      def client
-        @client ||= T.let(RunnerClient.create_client, T.nilable(RunnerClient))
+      sig { void }
+      def initialize
+        super
+
+        # We first initialize the client as a NullClient, so that we can start the server in a background thread. Until
+        # the real client is initialized, features that depend on it will not be blocked by using the NullClient
+        @client = T.let(NullClient.new, RunnerClient)
       end
 
       sig { override.params(message_queue: Thread::Queue).void }
       def activate(message_queue)
-        # Eagerly initialize the client in a thread. This allows the indexing from the Ruby LSP to continue running even
-        # while we boot large Rails applications in the background
-        Thread.new { client }
+        # Start booting the real client in a background thread. Until this completes, the client will be a NullClient
+        Thread.new { @client = RunnerClient.create_client }
       end
 
       sig { override.void }
       def deactivate
-        client.shutdown
+        @client.shutdown
       end
 
       # Creates a new CodeLens listener. This method is invoked on every CodeLens request
@@ -50,7 +53,7 @@ module RubyLsp
         ).void
       end
       def create_hover_listener(response_builder, nesting, index, dispatcher)
-        Hover.new(client, response_builder, nesting, index, dispatcher)
+        Hover.new(@client, response_builder, nesting, index, dispatcher)
       end
 
       sig { override.returns(String) }

--- a/ruby-lsp-rails.gemspec
+++ b/ruby-lsp-rails.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("actionpack", ">= 6.0")
   spec.add_dependency("activerecord", ">= 6.0")
   spec.add_dependency("railties", ">= 6.0")
-  spec.add_dependency("ruby-lsp", ">= 0.14.0", "< 0.15.0")
+  spec.add_dependency("ruby-lsp", ">= 0.14.2", "< 0.15.0")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9897")
 end

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -207,6 +207,13 @@ module RubyLsp
         store = RubyLsp::Store.new
         store.set(uri: uri, source: source, version: 1)
 
+        capture_subprocess_io do
+          RubyLsp::Executor.new(store, @message_queue).execute({
+            method: "initialized",
+            params: {},
+          })
+        end
+
         response = RubyLsp::Executor.new(store, @message_queue).execute({
           method: "textDocument/codeLens",
           params: { textDocument: { uri: uri }, position: { line: 0, character: 0 } },

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -195,21 +195,25 @@ module RubyLsp
           RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source
         )
 
-        response = T.let(nil, T.nilable(RubyLsp::Result))
-        capture_io do
-          response = executor.execute(
-            {
-              method: "textDocument/hover",
-              params: {
-                textDocument: { uri: uri },
-                position: position,
-              },
-            },
-          )
+        capture_subprocess_io do
+          RubyLsp::Executor.new(store, @message_queue).execute({
+            method: "initialized",
+            params: {},
+          })
         end
 
-        assert_nil(T.must(response).error)
-        T.must(response).response
+        response = executor.execute(
+          {
+            method: "textDocument/hover",
+            params: {
+              textDocument: { uri: uri },
+              position: position,
+            },
+          },
+        )
+
+        assert_nil(response.error)
+        response.response
       end
 
       def dummy_root


### PR DESCRIPTION
Because of the memoized `client` method, we had a race condition. Every time someone hovered over something while the runner was still booting it would try to boot another server, since the `@client` variable was not yet set.

This PR changes the way we use client to begin initializing it with a `NullClient`. That way, features that depend on the client like hover continue to operate normally.

On `activate`, we spawn a thread that will initialize the real client concurrently. Once the thread finishes, then subsequent requests will get the information coming from the real server, without blocking any hover requests during the process.

We also need to bump the requirement on `ruby-lsp` to get https://github.com/Shopify/ruby-lsp/pull/1400 or else the `initialize` method is not invoked properly.