### PR TITLE
Ensure addon is initiallized in document symbol test

### DIFF
--- a/test/ruby_lsp_rails/document_symbol_test.rb
+++ b/test/ruby_lsp_rails/document_symbol_test.rb
@@ -170,6 +170,13 @@ module RubyLsp
         store = RubyLsp::Store.new
         store.set(uri: uri, source: source, version: 1)
 
+        capture_subprocess_io do
+          RubyLsp::Executor.new(store, @message_queue).execute({
+            method: "initialized",
+            params: {},
+          })
+        end
+
         response = RubyLsp::Executor.new(store, @message_queue).execute({
           method: "textDocument/documentSymbol",
           params: { textDocument: { uri: uri }, position: { line: 0, character: 0 } },


### PR DESCRIPTION
With the new Ruby LSP version, we need to ensure `initialized` ran or else the addon may not be initialized. This fixes the main build.