### PR TITLE
Set process group ID in server to terminate after parent

### DIFF
--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -8,13 +8,13 @@ module RubyLsp
   module Rails
     class RunnerClientTest < ActiveSupport::TestCase
       setup do
-        capture_io do
+        capture_subprocess_io do
           @client = T.let(RunnerClient.new, RunnerClient)
         end
       end
 
       teardown do
-        @client.shutdown
+        capture_subprocess_io { @client.shutdown }
         assert_predicate @client, :stopped?
       end
 


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp-rails/issues/274

I think there are two issues with the way we shutdown the server. We can't have the infinite loop checking if the thread is alive, because something might go wrong with the server and then we'll never kill the child process. I removed that loop and switched to a single sleep to give some time for the server to shutdown.

Also, I started setting the process group ID in the server process. This is a similar trick used in [spring](https://github.com/rails/spring/blob/dee217996d2377e4f50bd61399d2431dbc6566d5/lib/spring/server.rb#L88), which makes it so that if the parent process is terminated, then so will the server.

I believe these two should help with the orphaned process issues we've been seeing.