### PR TITLE
Integrate document symbol for callbacks

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -12,6 +12,63 @@ module RubyLsp
       include Requests::Support::Common
       include ActiveSupportTestCaseHelper
 
+      MODEL_CALLBACKS = T.let(
+        [
+          "before_validation",
+          "after_validation",
+          "before_save",
+          "around_save",
+          "after_save",
+          "before_create",
+          "around_create",
+          "after_create",
+          "after_commit",
+          "after_rollback",
+          "before_update",
+          "around_update",
+          "after_update",
+          "before_destroy",
+          "around_destroy",
+          "after_destroy",
+          "after_initialize",
+          "after_find",
+          "after_touch",
+        ].freeze,
+        T::Array[String],
+      )
+
+      CONTROLLER_CALLBACKS = T.let(
+        [
+          "after_action",
+          "append_after_action",
+          "append_around_action",
+          "append_before_action",
+          "around_action",
+          "before_action",
+          "prepend_after_action",
+          "prepend_around_action",
+          "prepend_before_action",
+          "skip_after_action",
+          "skip_around_action",
+          "skip_before_action",
+        ].freeze,
+        T::Array[String],
+      )
+
+      JOB_CALLBACKS = T.let(
+        [
+          "after_enqueue",
+          "after_perform",
+          "around_enqueue",
+          "around_perform",
+          "before_enqueue",
+          "before_perform",
+        ].freeze,
+        T::Array[String],
+      )
+
+      CALLBACKS = T.let((MODEL_CALLBACKS + CONTROLLER_CALLBACKS + JOB_CALLBACKS).freeze, T::Array[String])
+
       sig do
         params(
           response_builder: ResponseBuilders::DocumentSymbol,
@@ -28,13 +85,115 @@ module RubyLsp
       def on_call_node_enter(node)
         content = extract_test_case_name(node)
 
-        return unless content
+        if content
+          append_document_symbol(
+            name: content,
+            selection_range: range_from_node(node),
+            range: range_from_node(node),
+          )
+        end
 
+        extract_callbacks(node)
+      end
+
+      private
+
+      sig { params(node: Prism::CallNode).void }
+      def extract_callbacks(node)
+        receiver = node.receiver
+        return if receiver && !receiver.is_a?(Prism::SelfNode)
+
+        message_value = node.message
+
+        return unless CALLBACKS.include?(message_value)
+
+        block = node.block
+
+        if block
+          append_document_symbol(
+            name: "#{message_value}(<anonymous>)",
+            range: range_from_location(node.location),
+            selection_range: range_from_location(block.location),
+          )
+          return
+        end
+
+        arguments = node.arguments&.arguments
+        return unless arguments&.any?
+
+        arguments.each do |argument|
+          case argument
+          when Prism::SymbolNode
+            name = argument.value
+            next unless name
+
+            append_document_symbol(
+              name: "#{message_value}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(T.must(argument.value_loc)),
+            )
+          when Prism::StringNode
+            name = argument.content
+            next if name.empty?
+
+            append_document_symbol(
+              name: "#{message_value}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(argument.content_loc),
+            )
+          when Prism::LambdaNode
+            append_document_symbol(
+              name: "#{message_value}(<anonymous>)",
+              range: range_from_location(node.location),
+              selection_range: range_from_location(argument.location),
+            )
+          when Prism::CallNode
+            arg_receiver = argument.receiver
+
+            name = arg_receiver.name if arg_receiver.is_a?(Prism::ConstantReadNode)
+            name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantPathNode)
+            next unless name
+
+            append_document_symbol(
+              name: "#{message_value}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(argument.location),
+            )
+          when Prism::ConstantReadNode
+            name = argument.name
+            next if name.empty?
+
+            append_document_symbol(
+              name: "#{message_value}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(argument.location),
+            )
+          when Prism::ConstantPathNode
+            name = argument.full_name
+            next if name.empty?
+
+            append_document_symbol(
+              name: "#{message_value}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(argument.location),
+            )
+          end
+        end
+      end
+
+      sig do
+        params(
+          name: String,
+          range: RubyLsp::Interface::Range,
+          selection_range: RubyLsp::Interface::Range,
+        ).void
+      end
+      def append_document_symbol(name:, range:, selection_range:)
         @response_builder.last.children << RubyLsp::Interface::DocumentSymbol.new(
-          name: content,
-          kind: LanguageServer::Protocol::Constant::SymbolKind::METHOD,
-          selection_range: range_from_node(node),
-          range: range_from_node(node),
+          name: name,
+          kind: RubyLsp::Constant::SymbolKind::METHOD,
+          range: range,
+          selection_range: selection_range,
         )
       end
     end

--- a/lib/ruby_lsp/ruby_lsp_rails/support/active_support_test_case_helper.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/active_support_test_case_helper.rb
@@ -11,8 +11,6 @@ module RubyLsp
         message_value = node.message
         return unless message_value == "test" || message_value == "it"
 
-        return unless node.arguments
-
         arguments = node.arguments&.arguments
         return unless arguments&.any?
 

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -2,4 +2,5 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  before_create :foo_arg, -> () {}
 end


### PR DESCRIPTION
Callbacks are ubiquitous across Rails, so it would be helpful to explicitly isolate them in the LSP via document symbols.

This approach accounts for callbacks associated with `ApplicationRecord` ([models](https://guides.rubyonrails.org/active_record_callbacks.html#available-callbacks)), `ApplicationController` ([controllers](https://api.rubyonrails.org/classes/AbstractController/Callbacks.html)), and `ApplicationJob` ([jobs](https://edgeapi.rubyonrails.org/classes/ActiveJob/Callbacks.html)).  

In addition to the various callback categories, there are 3 types of arguments to consider:
1. When the argument is a symbol (like `before_perform :foo_method`).
2. When the argument is a string (like `before_save "foo_method"`).
3. When the argument is a block (like   `before_action do ... end`).

So, this implementation looks like this:
1. Confirm the callback aligns with one of the callbacks offered by models/controllers/jobs.
2. Confirm the argument type is valid.
3. Create a document symbol for the callback-argument pairing.

As per this approach, something like `before_save "foo_method", "bar_method", on: :update` would yield two document symbols: `before_save(foo_method)` and `before_save(bar_method)`.

This approach directly ties to what is supported in Ruby LSP already for something like `attr_reader :foo`. 

See my thoughts below for additional context on the PR.

