### PR TITLE
Add reloading for schema changes

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -68,6 +68,15 @@ module RubyLsp
         DocumentSymbol.new(response_builder, dispatcher)
       end
 
+      sig { params(changes: T::Array[{ uri: String, type: Integer }]).void }
+      def workspace_did_change_watched_files(changes)
+        if changes.any? do |change|
+             change[:uri].end_with?("db/schema.rb") || change[:uri].end_with?("structure.sql")
+           end
+          @client.trigger_reload
+        end
+      end
+
       sig { override.returns(String) }
       def name
         "Ruby LSP Rails"

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -76,6 +76,15 @@ module RubyLsp
       end
 
       sig { void }
+      def trigger_reload
+        warn("Reloading Rails application")
+        send_notification("reload")
+      rescue IncompleteMessageError
+        warn("Ruby LSP Rails failed to trigger reload")
+        nil
+      end
+
+      sig { void }
       def shutdown
         warn("Ruby LSP Rails shutting down server")
         send_message("shutdown")

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -67,6 +67,9 @@ module RubyLsp
           VOID
         when "model"
           resolve_database_info_from_model(params.fetch(:name))
+        when "reload"
+          ::Rails.application.reloader.reload!
+          VOID
         else
           VOID
         end

--- a/test/ruby_lsp_rails/addon_test.rb
+++ b/test/ruby_lsp_rails/addon_test.rb
@@ -10,6 +10,45 @@ module RubyLsp
         addon = Addon.new
         assert_equal("Ruby LSP Rails", addon.name)
       end
+
+      test "sends reload notification if db/schema.rb is changed" do
+        changes = [
+          {
+            uri: "file://#{dummy_root}/db/schema.rb",
+            type: RubyLsp::Constant::FileChangeType::CHANGED,
+          },
+        ]
+
+        RunnerClient.any_instance.expects(:send_notification).with("reload").once
+        addon = Addon.new
+        addon.workspace_did_change_watched_files(changes)
+      end
+
+      test "sends reload notification if a *structure.sql file is changed" do
+        changes = [
+          {
+            uri: "file://#{dummy_root}/db/structure.sql",
+            type: RubyLsp::Constant::FileChangeType::CHANGED,
+          },
+        ]
+
+        RunnerClient.any_instance.expects(:send_notification).with("reload").once
+        addon = Addon.new
+        addon.workspace_did_change_watched_files(changes)
+      end
+
+      test "does not send reload notification if schema is not changed" do
+        changes = [
+          {
+            uri: "file://#{dummy_root}/app/models/foo.rb",
+            type: RubyLsp::Constant::FileChangeType::CHANGED,
+          },
+        ]
+
+        RunnerClient.any_instance.expects(:send_notification).never
+        addon = Addon.new
+        addon.workspace_did_change_watched_files(changes)
+      end
     end
   end
 end

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -215,10 +215,6 @@ module RubyLsp
         assert_nil(response.error)
         response.response
       end
-
-      def dummy_root
-        File.expand_path("#{__dir__}/../../test/dummy")
-      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,3 +17,11 @@ if defined?(DEBUGGER__)
   DEBUGGER__::CONFIG[:skip_path] =
     Array(DEBUGGER__::CONFIG[:skip_path]) + Gem.loaded_specs["sorbet-runtime"].full_require_paths
 end
+
+module ActiveSupport
+  class TestCase
+    def dummy_root
+      File.expand_path("#{__dir__}/dummy")
+    end
+  end
+end


### PR DESCRIPTION
This change goes along with https://github.com/Shopify/ruby-lsp/pull/1464 in ruby-lsp.

Partly addresses https://github.com/Shopify/ruby-lsp-rails/issues/257

We register for changes to the schema files, and trigger a reload so as to get the latest column information. (Using the same mechanism that `reload!` in the Rails console uses).