### PR TITLE
Implement document symbols for validations

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -148,6 +148,8 @@ module RubyLsp
               selection_range: range_from_location(argument.location),
             )
           when Prism::CallNode
+            next unless argument.name == :new
+
             arg_receiver = argument.receiver
 
             name = arg_receiver.name if arg_receiver.is_a?(Prism::ConstantReadNode)

--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -93,25 +93,29 @@ module RubyLsp
           )
         end
 
-        extract_callbacks(node)
+        receiver = node.receiver
+        return if receiver && !receiver.is_a?(Prism::SelfNode)
+
+        message = node.message
+        case message
+        when *CALLBACKS, "validate"
+          handle_all_arg_types(node, T.must(message))
+        when "validates", "validates!", "validates_each"
+          handle_symbol_and_string_arg_types(node, T.must(message))
+        when "validates_with"
+          handle_class_arg_types(node, T.must(message))
+        end
       end
 
       private
 
-      sig { params(node: Prism::CallNode).void }
-      def extract_callbacks(node)
-        receiver = node.receiver
-        return if receiver && !receiver.is_a?(Prism::SelfNode)
-
-        message_value = node.message
-
-        return unless CALLBACKS.include?(message_value)
-
+      sig { params(node: Prism::CallNode, message: String).void }
+      def handle_all_arg_types(node, message)
         block = node.block
 
         if block
           append_document_symbol(
-            name: "#{message_value}(<anonymous>)",
+            name: "#{message}(<anonymous>)",
             range: range_from_location(node.location),
             selection_range: range_from_location(block.location),
           )
@@ -128,7 +132,7 @@ module RubyLsp
             next unless name
 
             append_document_symbol(
-              name: "#{message_value}(#{name})",
+              name: "#{message}(#{name})",
               range: range_from_location(argument.location),
               selection_range: range_from_location(T.must(argument.value_loc)),
             )
@@ -137,13 +141,13 @@ module RubyLsp
             next if name.empty?
 
             append_document_symbol(
-              name: "#{message_value}(#{name})",
+              name: "#{message}(#{name})",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.content_loc),
             )
           when Prism::LambdaNode
             append_document_symbol(
-              name: "#{message_value}(<anonymous>)",
+              name: "#{message}(<anonymous>)",
               range: range_from_location(node.location),
               selection_range: range_from_location(argument.location),
             )
@@ -157,25 +161,65 @@ module RubyLsp
             next unless name
 
             append_document_symbol(
-              name: "#{message_value}(#{name})",
+              name: "#{message}(#{name})",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.location),
             )
-          when Prism::ConstantReadNode
-            name = argument.name
-            next if name.empty?
-
-            append_document_symbol(
-              name: "#{message_value}(#{name})",
-              range: range_from_location(argument.location),
-              selection_range: range_from_location(argument.location),
-            )
-          when Prism::ConstantPathNode
+          when Prism::ConstantReadNode, Prism::ConstantPathNode
             name = argument.full_name
             next if name.empty?
 
             append_document_symbol(
-              name: "#{message_value}(#{name})",
+              name: "#{message}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(argument.location),
+            )
+          end
+        end
+      end
+
+      sig { params(node: Prism::CallNode, message: String).void }
+      def handle_symbol_and_string_arg_types(node, message)
+        arguments = node.arguments&.arguments
+        return unless arguments&.any?
+
+        arguments.each do |argument|
+          case argument
+          when Prism::SymbolNode
+            name = argument.value
+            next unless name
+
+            append_document_symbol(
+              name: "#{message}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(T.must(argument.value_loc)),
+            )
+          when Prism::StringNode
+            name = argument.content
+            next if name.empty?
+
+            append_document_symbol(
+              name: "#{message}(#{name})",
+              range: range_from_location(argument.location),
+              selection_range: range_from_location(argument.content_loc),
+            )
+          end
+        end
+      end
+
+      sig { params(node: Prism::CallNode, message: String).void }
+      def handle_class_arg_types(node, message)
+        arguments = node.arguments&.arguments
+        return unless arguments&.any?
+
+        arguments.each do |argument|
+          case argument
+          when Prism::ConstantReadNode, Prism::ConstantPathNode
+            name = argument.full_name
+            next if name.empty?
+
+            append_document_symbol(
+              name: "#{message}(#{name})",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.location),
             )

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -3,4 +3,5 @@
 
 class User < ApplicationRecord
   before_create :foo_arg, -> () {}
+  validates :name, presence: true
 end

--- a/test/ruby_lsp_rails/document_symbol_test.rb
+++ b/test/ruby_lsp_rails/document_symbol_test.rb
@@ -287,6 +287,68 @@ module RubyLsp
         assert_empty(response[0].children)
       end
 
+      test "correctly handles validate method with all argument types" do
+        response = generate_document_symbols_for_source(<<~RUBY)
+          class FooModel < ApplicationRecord
+            validate "foo_arg", :bar_arg, -> () {}, Foo::BazClass.new("blah"), FooClass, Foo::BarClass
+          end
+        RUBY
+
+        assert_equal(1, response.size)
+        assert_equal("FooModel", response[0].name)
+        assert_equal(6, response[0].children.size)
+        assert_equal("validate(foo_arg)", response[0].children[0].name)
+        assert_equal("validate(bar_arg)", response[0].children[1].name)
+        assert_equal("validate(<anonymous>)", response[0].children[2].name)
+        assert_equal("validate(Foo::BazClass)", response[0].children[3].name)
+        assert_equal("validate(FooClass)", response[0].children[4].name)
+        assert_equal("validate(Foo::BarClass)", response[0].children[5].name)
+      end
+
+      test "correctly handles validates method with Prism::StringNode and Prism::SymbolNode argument types" do
+        response = generate_document_symbols_for_source(<<~RUBY)
+          class FooModel < ApplicationRecord
+            validates "foo_arg", :bar_arg
+          end
+        RUBY
+
+        assert_equal(1, response.size)
+        assert_equal("FooModel", response[0].name)
+        assert_equal(2, response[0].children.size)
+        assert_equal("validates(foo_arg)", response[0].children[0].name)
+        assert_equal("validates(bar_arg)", response[0].children[1].name)
+      end
+
+      test "correctly handles validates_each method with Prism::StringNode and Prism::SymbolNode argument types" do
+        response = generate_document_symbols_for_source(<<~RUBY)
+          class FooModel < ApplicationRecord
+            validates_each "foo_arg", :bar_arg do
+              puts "Foo"
+            end
+          end
+        RUBY
+
+        assert_equal(1, response.size)
+        assert_equal("FooModel", response[0].name)
+        assert_equal(2, response[0].children.size)
+        assert_equal("validates_each(foo_arg)", response[0].children[0].name)
+        assert_equal("validates_each(bar_arg)", response[0].children[1].name)
+      end
+
+      test "correctly handles validates_with method with Prism::ConstantReadNode and Prism::ConstantPathNode argument types" do
+        response = generate_document_symbols_for_source(<<~RUBY)
+          class FooModel < ApplicationRecord
+            validates_with FooClass, Foo::BarClass
+          end
+        RUBY
+
+        assert_equal(1, response.size)
+        assert_equal("FooModel", response[0].name)
+        assert_equal(2, response[0].children.size)
+        assert_equal("validates_with(FooClass)", response[0].children[0].name)
+        assert_equal("validates_with(Foo::BarClass)", response[0].children[1].name)
+      end
+
       private
 
       def generate_document_symbols_for_source(source)

--- a/test/ruby_lsp_rails/document_symbol_test.rb
+++ b/test/ruby_lsp_rails/document_symbol_test.rb
@@ -163,7 +163,7 @@ module RubyLsp
         assert_equal("back to the same level", response[0].children[2].name)
       end
 
-      test "correctly handles model callbacks with multiple Prism::StringNode arguments" do
+      test "correctly handles model callbacks with multiple string arguments" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooModel < ApplicationRecord
             before_save "foo_method", "bar_method", on: :update
@@ -192,7 +192,7 @@ module RubyLsp
         assert_equal("before_action(<anonymous>)", response[0].children[0].name)
       end
 
-      test "correctly handles job callback with Prism::SymbolNode argument" do
+      test "correctly handles job callback with symbol argument" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooJob < ApplicationJob
             before_perform :foo_method
@@ -205,7 +205,7 @@ module RubyLsp
         assert_equal("before_perform(foo_method)", response[0].children[0].name)
       end
 
-      test "correctly handles model callback with Prism::LambdaNode argument" do
+      test "correctly handles model callback with lambda argument" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooModel < ApplicationRecord
             before_save -> () {}
@@ -218,7 +218,7 @@ module RubyLsp
         assert_equal("before_save(<anonymous>)", response[0].children[0].name)
       end
 
-      test "correctly handles job callbacks with Prism::CallNode argument" do
+      test "correctly handles job callbacks with method call argument" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooJob < ApplicationJob
             before_perform FooClass.new(foo_arg)
@@ -231,7 +231,7 @@ module RubyLsp
         assert_equal("before_perform(FooClass)", response[0].children[0].name)
       end
 
-      test "correctly handles controller callbacks with Prism::ConstantReadNode argument" do
+      test "correctly handles controller callbacks with constant argument" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooController < ApplicationController
             before_action FooClass
@@ -244,7 +244,7 @@ module RubyLsp
         assert_equal("before_action(FooClass)", response[0].children[0].name)
       end
 
-      test "correctly handles model callbacks with Prism::ConstantPathNode argument" do
+      test "correctly handles model callbacks with namespaced constant argument" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooModel < ApplicationRecord
             before_save Foo::BarClass
@@ -305,7 +305,7 @@ module RubyLsp
         assert_equal("validate(Foo::BarClass)", response[0].children[5].name)
       end
 
-      test "correctly handles validates method with Prism::StringNode and Prism::SymbolNode argument types" do
+      test "correctly handles validates method with string and symbol argument types" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooModel < ApplicationRecord
             validates "foo_arg", :bar_arg
@@ -319,7 +319,7 @@ module RubyLsp
         assert_equal("validates(bar_arg)", response[0].children[1].name)
       end
 
-      test "correctly handles validates_each method with Prism::StringNode and Prism::SymbolNode argument types" do
+      test "correctly handles validates_each method with string and symbol argument types" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooModel < ApplicationRecord
             validates_each "foo_arg", :bar_arg do
@@ -335,7 +335,7 @@ module RubyLsp
         assert_equal("validates_each(bar_arg)", response[0].children[1].name)
       end
 
-      test "correctly handles validates_with method with Prism::ConstantReadNode and Prism::ConstantPathNode argument types" do
+      test "correctly handles validates_with method with constant and namespaced constant argument types" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooModel < ApplicationRecord
             validates_with FooClass, Foo::BarClass


### PR DESCRIPTION
Implements document symbol for the various types of Rails validations.

The remaining dsl feature is relationships. Based on my experience in this PR, it looks like the manner in which we handle each type of dsl feature doesn't generalize particularly cleanly. Consequently, after all the features are implemented, we can then reflect on the appropriate abstraction. Abstracting before comprehensive feature completion might cause us to create abstractions that we have to later rectify.

For now, these changes are scoped to focus on implementing validations exclusively. 