### PR TITLE
Use `$stderr.puts` instead of `warn`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,3 @@ Sorbet/StrictSigil:
   Exclude:
     - "**/*.rake"
     - "test/**/*.rb"
-
-Style/StderrPuts:
-  Enabled: true

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -14,8 +14,8 @@ module RubyLsp
         def create_client
           new
         rescue Errno::ENOENT, StandardError => e # rubocop:disable Lint/ShadowedException
-          warn("Ruby LSP Rails failed to initialize server: #{e.message}\n#{e.backtrace&.join("\n")}")
-          warn("Server dependent features will not be available")
+          $stderr.puts("Ruby LSP Rails failed to initialize server: #{e.message}\n#{e.backtrace&.join("\n")}")
+          $stderr.puts("Server dependent features will not be available")
           NullClient.new
         end
       end
@@ -50,14 +50,14 @@ module RubyLsp
         @stdin.binmode # for Windows compatibility
         @stdout.binmode # for Windows compatibility
 
-        warn("Ruby LSP Rails booting server")
+        $stderr.puts("Ruby LSP Rails booting server")
         read_response
-        warn("Finished booting Ruby LSP Rails server")
+        $stderr.puts("Finished booting Ruby LSP Rails server")
 
         unless ENV["RAILS_ENV"] == "test"
           at_exit do
             if @wait_thread.alive?
-              warn("Ruby LSP Rails is force killing the server")
+              $stderr.puts("Ruby LSP Rails is force killing the server")
               sleep(0.5) # give the server a bit of time if we already issued a shutdown notification
               Process.kill(T.must(Signal.list["TERM"]), @wait_thread.pid)
             end
@@ -71,22 +71,22 @@ module RubyLsp
       def model(name)
         make_request("model", name: name)
       rescue IncompleteMessageError
-        warn("Ruby LSP Rails failed to get model information: #{@stderr.read}")
+        $stderr.puts("Ruby LSP Rails failed to get model information: #{@stderr.read}")
         nil
       end
 
       sig { void }
       def trigger_reload
-        warn("Reloading Rails application")
+        $stderr.puts("Reloading Rails application")
         send_notification("reload")
       rescue IncompleteMessageError
-        warn("Ruby LSP Rails failed to trigger reload")
+        $stderr.puts("Ruby LSP Rails failed to trigger reload")
         nil
       end
 
       sig { void }
       def shutdown
-        warn("Ruby LSP Rails shutting down server")
+        $stderr.puts("Ruby LSP Rails shutting down server")
         send_message("shutdown")
         sleep(0.5) # give the server a bit of time to shutdown
         [@stdin, @stdout, @stderr].each(&:close)
@@ -130,7 +130,7 @@ module RubyLsp
         response = JSON.parse(T.must(raw_response), symbolize_names: true)
 
         if response[:error]
-          warn("Ruby LSP Rails error: " + response[:error])
+          $stderr.puts("Ruby LSP Rails error: " + response[:error])
           return
         end
 

--- a/lib/ruby_lsp/ruby_lsp_rails/support/rails_document_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/rails_document_client.rb
@@ -66,7 +66,7 @@ module RubyLsp
           private def build_search_index
             return unless RAILTIES_VERSION
 
-            warn("Fetching Rails Documents...")
+            $stderr.puts("Fetching Rails Documents...")
 
             response = Net::HTTP.get_response(URI("#{RAILS_DOC_HOST}/v#{RAILTIES_VERSION}/js/search_index.js"))
 
@@ -79,13 +79,13 @@ module RubyLsp
               response = Net::HTTP.get_response(URI("#{RAILS_DOC_HOST}/js/search_index.js"))
               response.body if response.is_a?(Net::HTTPSuccess)
             else
-              warn("Response failed: #{response.inspect}")
+              $stderr.puts("Response failed: #{response.inspect}")
               nil
             end
 
             process_search_index(body) if body
           rescue StandardError => e
-            warn("Exception occurred when fetching Rails document index: #{e.inspect}")
+            $stderr.puts("Exception occurred when fetching Rails document index: #{e.inspect}")
           end
 
           sig { params(js: String).returns(T::Hash[String, T::Array[T::Hash[Symbol, String]]]) }


### PR DESCRIPTION
To prevent behaviour being affect by the `VERBOSE` setting, as mentioned [here](https://github.com/Shopify/ruby-lsp-rails/pull/284/files#r1517805630).