### PR TITLE
Implement document symbol for associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There is no need to add the gem to your bundle.
 
 * Hover over an ActiveRecord model to reveal its schema.
 * Run or debug a test by clicking on the code lens which appears above the test class, or an individual test.
-* Navigate to validations, callbacks and test cases using your editor's "Go to Symbol" feature, or outline view.
+* Navigate to associations, validations, callbacks and test cases using your editor's "Go to Symbol" feature, or outline view.
 
 ## Documentation
 

--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -6,7 +6,8 @@ module RubyLsp
     # ![Document Symbol demo](../../document_symbol.gif)
     #
     # The [document symbol](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol)
-    # request allows users to navigate between ActiveSupport test cases with VS Code's "Go to Symbol" feature.
+    # request allows users to navigate between associations, validations, callbacks and ActiveSupport test cases with
+    # VS Code's "Go to Symbol" feature.
     class DocumentSymbol
       extend T::Sig
       include Requests::Support::Common
@@ -100,7 +101,7 @@ module RubyLsp
         case message
         when *CALLBACKS, "validate"
           handle_all_arg_types(node, T.must(message))
-        when "validates", "validates!", "validates_each"
+        when "validates", "validates!", "validates_each", "belongs_to", "has_one", "has_many", "has_and_belongs_to_many"
           handle_symbol_and_string_arg_types(node, T.must(message))
         when "validates_with"
           handle_class_arg_types(node, T.must(message))

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -4,4 +4,5 @@
 class User < ApplicationRecord
   before_create :foo_arg, -> () {}
   validates :name, presence: true
+  has_one :profile
 end

--- a/test/ruby_lsp_rails/document_symbol_test.rb
+++ b/test/ruby_lsp_rails/document_symbol_test.rb
@@ -349,6 +349,21 @@ module RubyLsp
         assert_equal("validates_with(Foo::BarClass)", response[0].children[1].name)
       end
 
+      test "correctly handles association callbacks with string and symbol argument types" do
+        response = generate_document_symbols_for_source(<<~RUBY)
+          class FooModel < ApplicationRecord
+            belongs_to :foo
+            belongs_to "baz"
+          end
+        RUBY
+
+        assert_equal(1, response.size)
+        assert_equal("FooModel", response[0].name)
+        assert_equal(2, response[0].children.size)
+        assert_equal("belongs_to(foo)", response[0].children[0].name)
+        assert_equal("belongs_to(baz)", response[0].children[1].name)
+      end
+
       private
 
       def generate_document_symbols_for_source(source)


### PR DESCRIPTION
Implements the document symbol for various associations supported in Rails.

Any potential refactoring can be scoped out of this for now — this PR is focused on supporting the feature. 