### PR TITLE
Change symbol appearance for Rails macros

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -161,10 +161,6 @@ module RubyLsp
             name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantPathNode)
             next unless name
 
-            unless arg_receiver.is_a?(Prism::ConstantReadNode) || arg_receiver.is_a?(Prism::ConstantPathNode)
-              name = ":#{name}"
-            end
-
             append_document_symbol(
               name: "#{message} #{name}",
               range: range_from_location(argument.location),

--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -157,8 +157,7 @@ module RubyLsp
 
             arg_receiver = argument.receiver
 
-            name = arg_receiver.name if arg_receiver.is_a?(Prism::ConstantReadNode)
-            name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantPathNode)
+            name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantReadNode) || arg_receiver.is_a?(Prism::ConstantPathNode)
             next unless name
 
             append_document_symbol(

--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -116,7 +116,7 @@ module RubyLsp
 
         if block
           append_document_symbol(
-            name: "#{message}(<anonymous>)",
+            name: "#{message} <anonymous>",
             range: range_from_location(node.location),
             selection_range: range_from_location(block.location),
           )
@@ -133,7 +133,7 @@ module RubyLsp
             next unless name
 
             append_document_symbol(
-              name: "#{message}(#{name})",
+              name: "#{message} :#{name}",
               range: range_from_location(argument.location),
               selection_range: range_from_location(T.must(argument.value_loc)),
             )
@@ -142,13 +142,13 @@ module RubyLsp
             next if name.empty?
 
             append_document_symbol(
-              name: "#{message}(#{name})",
+              name: "#{message} :#{name}",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.content_loc),
             )
           when Prism::LambdaNode
             append_document_symbol(
-              name: "#{message}(<anonymous>)",
+              name: "#{message} <anonymous>",
               range: range_from_location(node.location),
               selection_range: range_from_location(argument.location),
             )
@@ -161,8 +161,12 @@ module RubyLsp
             name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantPathNode)
             next unless name
 
+            unless arg_receiver.is_a?(Prism::ConstantReadNode) || arg_receiver.is_a?(Prism::ConstantPathNode)
+              name = ":#{name}"
+            end
+
             append_document_symbol(
-              name: "#{message}(#{name})",
+              name: "#{message} #{name}",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.location),
             )
@@ -171,7 +175,7 @@ module RubyLsp
             next if name.empty?
 
             append_document_symbol(
-              name: "#{message}(#{name})",
+              name: "#{message} #{name}",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.location),
             )
@@ -191,7 +195,7 @@ module RubyLsp
             next unless name
 
             append_document_symbol(
-              name: "#{message}(#{name})",
+              name: "#{message} :#{name}",
               range: range_from_location(argument.location),
               selection_range: range_from_location(T.must(argument.value_loc)),
             )
@@ -200,7 +204,7 @@ module RubyLsp
             next if name.empty?
 
             append_document_symbol(
-              name: "#{message}(#{name})",
+              name: "#{message} :#{name}",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.content_loc),
             )
@@ -220,7 +224,7 @@ module RubyLsp
             next if name.empty?
 
             append_document_symbol(
-              name: "#{message}(#{name})",
+              name: "#{message} #{name}",
               range: range_from_location(argument.location),
               selection_range: range_from_location(argument.location),
             )

--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -157,7 +157,8 @@ module RubyLsp
 
             arg_receiver = argument.receiver
 
-            name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantReadNode) || arg_receiver.is_a?(Prism::ConstantPathNode)
+            name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantReadNode) ||
+              arg_receiver.is_a?(Prism::ConstantPathNode)
             next unless name
 
             append_document_symbol(

--- a/test/ruby_lsp_rails/document_symbol_test.rb
+++ b/test/ruby_lsp_rails/document_symbol_test.rb
@@ -173,8 +173,8 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(2, response[0].children.size)
-        assert_equal("before_save(foo_method)", response[0].children[0].name)
-        assert_equal("before_save(bar_method)", response[0].children[1].name)
+        assert_equal("before_save :foo_method", response[0].children[0].name)
+        assert_equal("before_save :bar_method", response[0].children[1].name)
       end
 
       test "correctly handles controller callback with block" do
@@ -189,7 +189,7 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooController", response[0].name)
         assert_equal(1, response[0].children.size)
-        assert_equal("before_action(<anonymous>)", response[0].children[0].name)
+        assert_equal("before_action <anonymous>", response[0].children[0].name)
       end
 
       test "correctly handles job callback with symbol argument" do
@@ -202,7 +202,7 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooJob", response[0].name)
         assert_equal(1, response[0].children.size)
-        assert_equal("before_perform(foo_method)", response[0].children[0].name)
+        assert_equal("before_perform :foo_method", response[0].children[0].name)
       end
 
       test "correctly handles model callback with lambda argument" do
@@ -215,7 +215,7 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(1, response[0].children.size)
-        assert_equal("before_save(<anonymous>)", response[0].children[0].name)
+        assert_equal("before_save <anonymous>", response[0].children[0].name)
       end
 
       test "correctly handles job callbacks with method call argument" do
@@ -228,7 +228,7 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooJob", response[0].name)
         assert_equal(1, response[0].children.size)
-        assert_equal("before_perform(FooClass)", response[0].children[0].name)
+        assert_equal("before_perform FooClass", response[0].children[0].name)
       end
 
       test "correctly handles controller callbacks with constant argument" do
@@ -241,7 +241,7 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooController", response[0].name)
         assert_equal(1, response[0].children.size)
-        assert_equal("before_action(FooClass)", response[0].children[0].name)
+        assert_equal("before_action FooClass", response[0].children[0].name)
       end
 
       test "correctly handles model callbacks with namespaced constant argument" do
@@ -254,7 +254,7 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(1, response[0].children.size)
-        assert_equal("before_save(Foo::BarClass)", response[0].children[0].name)
+        assert_equal("before_save Foo::BarClass", response[0].children[0].name)
       end
 
       test "correctly handles job callbacks with all argument types" do
@@ -267,12 +267,12 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooJob", response[0].name)
         assert_equal(6, response[0].children.size)
-        assert_equal("before_perform(foo_arg)", response[0].children[0].name)
-        assert_equal("before_perform(bar_arg)", response[0].children[1].name)
-        assert_equal("before_perform(<anonymous>)", response[0].children[2].name)
-        assert_equal("before_perform(Foo::BazClass)", response[0].children[3].name)
-        assert_equal("before_perform(FooClass)", response[0].children[4].name)
-        assert_equal("before_perform(Foo::BarClass)", response[0].children[5].name)
+        assert_equal("before_perform :foo_arg", response[0].children[0].name)
+        assert_equal("before_perform :bar_arg", response[0].children[1].name)
+        assert_equal("before_perform <anonymous>", response[0].children[2].name)
+        assert_equal("before_perform Foo::BazClass", response[0].children[3].name)
+        assert_equal("before_perform FooClass", response[0].children[4].name)
+        assert_equal("before_perform Foo::BarClass", response[0].children[5].name)
       end
 
       test "ignore unrecognized callback" do
@@ -297,12 +297,12 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(6, response[0].children.size)
-        assert_equal("validate(foo_arg)", response[0].children[0].name)
-        assert_equal("validate(bar_arg)", response[0].children[1].name)
-        assert_equal("validate(<anonymous>)", response[0].children[2].name)
-        assert_equal("validate(Foo::BazClass)", response[0].children[3].name)
-        assert_equal("validate(FooClass)", response[0].children[4].name)
-        assert_equal("validate(Foo::BarClass)", response[0].children[5].name)
+        assert_equal("validate :foo_arg", response[0].children[0].name)
+        assert_equal("validate :bar_arg", response[0].children[1].name)
+        assert_equal("validate <anonymous>", response[0].children[2].name)
+        assert_equal("validate Foo::BazClass", response[0].children[3].name)
+        assert_equal("validate FooClass", response[0].children[4].name)
+        assert_equal("validate Foo::BarClass", response[0].children[5].name)
       end
 
       test "correctly handles validates method with string and symbol argument types" do
@@ -315,8 +315,8 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(2, response[0].children.size)
-        assert_equal("validates(foo_arg)", response[0].children[0].name)
-        assert_equal("validates(bar_arg)", response[0].children[1].name)
+        assert_equal("validates :foo_arg", response[0].children[0].name)
+        assert_equal("validates :bar_arg", response[0].children[1].name)
       end
 
       test "correctly handles validates_each method with string and symbol argument types" do
@@ -331,8 +331,8 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(2, response[0].children.size)
-        assert_equal("validates_each(foo_arg)", response[0].children[0].name)
-        assert_equal("validates_each(bar_arg)", response[0].children[1].name)
+        assert_equal("validates_each :foo_arg", response[0].children[0].name)
+        assert_equal("validates_each :bar_arg", response[0].children[1].name)
       end
 
       test "correctly handles validates_with method with constant and namespaced constant argument types" do
@@ -345,8 +345,8 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(2, response[0].children.size)
-        assert_equal("validates_with(FooClass)", response[0].children[0].name)
-        assert_equal("validates_with(Foo::BarClass)", response[0].children[1].name)
+        assert_equal("validates_with FooClass", response[0].children[0].name)
+        assert_equal("validates_with Foo::BarClass", response[0].children[1].name)
       end
 
       test "correctly handles association callbacks with string and symbol argument types" do
@@ -360,8 +360,8 @@ module RubyLsp
         assert_equal(1, response.size)
         assert_equal("FooModel", response[0].name)
         assert_equal(2, response[0].children.size)
-        assert_equal("belongs_to(foo)", response[0].children[0].name)
-        assert_equal("belongs_to(baz)", response[0].children[1].name)
+        assert_equal("belongs_to :foo", response[0].children[0].name)
+        assert_equal("belongs_to :baz", response[0].children[1].name)
       end
 
       private


### PR DESCRIPTION
This changes how we display symbols for Rails macros, so that:

- It's easier to visual distinguish them from regular methods
- They are a closer represention to how the macros are typically written in code.