### PR TITLE
Show addon version while booting

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -27,6 +27,7 @@ module RubyLsp
 
       sig { override.params(message_queue: Thread::Queue).void }
       def activate(message_queue)
+        $stderr.puts("Activating Ruby LSP Rails addon v#{VERSION}")
         # Start booting the real client in a background thread. Until this completes, the client will be a NullClient
         Thread.new { @client = RunnerClient.create_client }
       end


### PR DESCRIPTION
Useful for troubleshooting.

Example output:
```
2024-03-22 14:16:54.980 [info] (ruby-lsp-rails) Starting Ruby LSP v0.14.6...

2024-03-22 14:16:55.416 [info] (ruby-lsp-rails) Activating Ruby LSP Rails v0.3.3
```