### PR TITLE
Remove Ruby version restriction for docs publishing

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2 # `bundle exec rake rdoc` fails on 3.3.0
           bundler-cache: true
 
       - name: Configure git


### PR DESCRIPTION
Same as https://github.com/Shopify/ruby-lsp/pull/1832