### PR TITLE
Set default CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - Gemfile: "gemfiles/Gemfile-rails-main" # needs Ruby 3.1
             ruby: "3.0"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     continue-on-error: ${{ !!matrix.experimental }}


### PR DESCRIPTION
To avoid jobs running continuously if there's a problem, like [this](https://github.com/Shopify/ruby-lsp/actions/runs/8440035436/job/23116030503).

(I think the default is 24h).