### PR TITLE
Add primary key indicator to model hover response

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -83,7 +83,8 @@ module RubyLsp
 
         @response_builder.push(
           model[:columns].map do |name, type|
-            "**#{name}**: #{type}\n"
+            primary_key_suffix = " (PK)" if model[:primary_keys].include?(name)
+            "**#{name}**: #{type}#{primary_key_suffix}\n"
           end.join("\n"),
           category: :documentation,
         )

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -91,6 +91,7 @@ module RubyLsp
         info = {
           result: {
             columns: const.columns.map { |column| [column.name, column.type] },
+            primary_keys: Array(const.primary_key),
           },
         }
 

--- a/test/dummy/app/models/composite_primary_key.rb
+++ b/test/dummy/app/models/composite_primary_key.rb
@@ -1,0 +1,5 @@
+# typed: true
+# frozen_string_literal: true
+
+class CompositePrimaryKey < ApplicationRecord
+end

--- a/test/dummy/db/migrate/20240403145625_create_composite_pk.rb
+++ b/test/dummy/db/migrate/20240403145625_create_composite_pk.rb
@@ -1,0 +1,11 @@
+class CreateCompositePk < ActiveRecord::Migration[7.1]
+  def change
+    create_table :composite_primary_keys, primary_key: [:order_id, :product_id] do |t|
+      t.integer :order_id
+      t.integer :product_id
+      t.text :note
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_19_180159) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_03_145625) do
+  create_table "composite_primary_keys", primary_key: ["order_id", "product_id"], force: :cascade do |t|
+    t.integer "order_id"
+    t.integer "product_id"
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.text "body"


### PR DESCRIPTION
Closes #313

Rails 7.1 supports composite primary keys so the return type will either be a string or an array of strings, depending on the pk type. I've added a test for that case.

I was a bit surprised that the tests don't go through `resolve_database_info_from_model`. I guess because it would involve the runner and require db setup? Anyways, I tested it manually and this is what it looks like: 
![image](https://github.com/Shopify/ruby-lsp-rails/assets/14981592/a5227fd3-2afe-48c8-b087-2c1019f602d3)
![image](https://github.com/Shopify/ruby-lsp-rails/assets/14981592/a36b4d82-bfb4-4a4b-9b6f-991362812778)
