### PR TITLE
Don't push group id to stack when encountering non-test classes

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -88,15 +88,17 @@ module RubyLsp
         if class_name.end_with?("Test")
           command = "#{BASE_COMMAND} #{@path}"
           add_test_code_lens(node, name: class_name, command: command, kind: :group)
+          @group_id_stack.push(@group_id)
+          @group_id += 1
         end
-
-        @group_id_stack.push(@group_id)
-        @group_id += 1
       end
 
       sig { params(node: Prism::ClassNode).void }
       def on_class_node_leave(node)
-        @group_id_stack.pop
+        class_name = node.constant_path.slice
+        if class_name.end_with?("Test")
+          @group_id_stack.pop
+        end
       end
 
       private


### PR DESCRIPTION
Some tests use classes instead of modules for namespacing, such us:

```ruby
module Foo
  class Bar
    class MyTest < ActiveSupport::TestCase
      test "something" do
      end
    end
  end
end
```

And when this happens, the current implementation would still push the group id to the stack, which would cause the first test group (`MyTest`) to already have non-nil group id. This will make the extension to think there's another parent test group, which is not the case and will cause no code lens to be shown.

This commit fixes this by not pushing the group id to the stack when encountering non-test classes, and only pop the group id when the encountered class is a test class.