### PR TITLE
Prevent crash during ActiveRecord const check

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -82,7 +82,7 @@ module RubyLsp
       sig { params(model_name: String).returns(T::Hash[Symbol, T.untyped]) }
       def resolve_database_info_from_model(model_name)
         const = ActiveSupport::Inflector.safe_constantize(model_name)
-        unless const && defined?(ActiveRecord) && const < ActiveRecord::Base && !const.abstract_class?
+        unless active_record_model?(const)
           return {
             result: nil,
           }
@@ -103,6 +103,16 @@ module RubyLsp
         info
       rescue => e
         { error: e.full_message(highlight: false) }
+      end
+
+      sig { params(const: T.untyped).returns(T::Boolean) }
+      def active_record_model?(const)
+        !!(
+          const &&
+            defined?(ActiveRecord) &&
+            ActiveRecord::Base > const && # We do this 'backwards' in case the class overwrites `<`
+          !const.abstract_class?
+        )
       end
     end
   end

--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -24,6 +24,19 @@ class ServerTest < ActiveSupport::TestCase
     assert_nil(response.fetch(:result))
   end
 
+  test "doesn't fail if the class overrides `<`" do
+    class TestClassWithOverwrittenLessThan
+      class << self
+        def <(other)
+          raise
+        end
+      end
+    end
+
+    response = @server.execute("model", { name: "TestClassWithOverwrittenLessThan" })
+    assert_nil(response.fetch(:result))
+  end
+
   test "handles older Rails version which don't have `schema_dump_path`" do
     ActiveRecord::Tasks::DatabaseTasks.send(:alias_method, :old_schema_dump_path, :schema_dump_path)
     ActiveRecord::Tasks::DatabaseTasks.undef_method(:schema_dump_path)


### PR DESCRIPTION
I'm not exactly sure how it was triggered, but I had crash for this:

```
undefined method `<' for an instance of T::Private::Types::TypeAlias (NoMethodError)
```

I'll add a test if I'm able to reproduce.