### PR TITLE
Add Definition support for routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,8 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/Gemfile-rails-main
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
         include:
-          - ruby: "head"
-            experimental: true
           - gemfile: "gemfiles/Gemfile-rails-main"
             experimental: true
         exclude:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Ruby LSP Rails is a [Ruby LSP](https://github.com/Shopify/ruby-lsp) addon for ex
 * Run or debug a test by clicking on the code lens which appears above the test class, or an individual test.
 * Navigate to associations, validations, callbacks and test cases using your editor's "Go to Symbol" feature, or outline view.
 * Jump to the definition of callbacks using your editor's "Go to Definition" feature.
+* Jump to the declaration of a route.
 
 ## Installation
 

--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -31,7 +31,7 @@ module RubyLsp
         @global_state = T.let(global_state, T.nilable(RubyLsp::GlobalState))
         $stderr.puts("Activating Ruby LSP Rails addon v#{VERSION}")
         # Start booting the real client in a background thread. Until this completes, the client will be a NullClient
-        Thread.new { @client = RunnerClient.create_client }
+        Thread.new { @client = RunnerClient.create_client }.join
       end
 
       sig { override.void }
@@ -84,7 +84,7 @@ module RubyLsp
       end
       def create_definition_listener(response_builder, uri, nesting, dispatcher)
         index = T.must(@global_state).index
-        Definition.new(response_builder, nesting, index, dispatcher)
+        Definition.new(@client, response_builder, nesting, index, dispatcher)
       end
 
       sig { params(changes: T::Array[{ uri: String, type: Integer }]).void }

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -93,6 +93,14 @@ module RubyLsp
         nil
       end
 
+      sig { params(name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      def route_location(name)
+        make_request("route_location", name: name)
+      rescue IncompleteMessageError
+        $stderr.puts("Ruby LSP Rails failed to get route location: #{@stderr.read}")
+        nil
+      end
+
       sig { void }
       def trigger_reload
         $stderr.puts("Reloading Rails application")

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  def create
+    user_path(1)
+    user_url(1)
+    users_path
+    archive_users_path
+    invalid_path
+  end
 end

--- a/test/dummy/config/initializers/action_dispatch.rb
+++ b/test/dummy/config/initializers/action_dispatch.rb
@@ -1,0 +1,5 @@
+# typed: true
+# frozen_string_literal: true
+
+# Route source locations are normally only available in development, so we need to enable this in test mode.
+ActionDispatch::Routing::Mapper.route_source_locations = true

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :users do
+    get :archive, on: :collection
+  end
 end

--- a/test/ruby_lsp_rails/definition_test.rb
+++ b/test/ruby_lsp_rails/definition_test.rb
@@ -80,6 +80,46 @@ module RubyLsp
         assert_equal(14, response[1].range.end.character)
       end
 
+      test "provides the definition of a route" do
+        response = generate_definitions_for_source(<<~RUBY, { line: 0, character: 0 })
+          users_path
+        RUBY
+
+        assert_equal(1, response.size)
+        dummy_root = File.expand_path("../dummy", __dir__)
+        assert_equal("file://#{dummy_root}/config/routes.rb", response[0].uri)
+        assert_equal(3, response[0].range.start.line)
+        assert_equal(3, response[0].range.end.line)
+      end
+
+      test "handles incomplete routes" do
+        response = generate_definitions_for_source(<<~RUBY, { line: 0, character: 0 })
+          _path
+        RUBY
+
+        assert_empty(response)
+      end
+
+      test "provides the definition of a custom route" do
+        response = generate_definitions_for_source(<<~RUBY, { line: 0, character: 0 })
+          archive_users_path
+        RUBY
+
+        assert_equal(1, response.size)
+        dummy_root = File.expand_path("../dummy", __dir__)
+        assert_equal("file://#{dummy_root}/config/routes.rb", response[0].uri)
+        assert_equal(4, response[0].range.start.line)
+        assert_equal(4, response[0].range.end.line)
+      end
+
+      test "ignored non-existing routes" do
+        response = generate_definitions_for_source(<<~RUBY, { line: 0, character: 0 })
+          invalid_path
+        RUBY
+
+        assert_empty(response)
+      end
+
       private
 
       def generate_definitions_for_source(source, position)

--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -45,4 +45,15 @@ class ServerTest < ActiveSupport::TestCase
   ensure
     ActiveRecord::Tasks::DatabaseTasks.send(:alias_method, :schema_dump_path, :old_schema_dump_path)
   end
+
+  test "route location returns the location for a valid route" do
+    response = @server.execute("route_location", { name: "user_path" })
+    location = response[:result][:location]
+    assert_match %r{test/dummy/config/routes.rb:4$}, location
+  end
+
+  test "route location returns nil for invalid routes" do
+    response = @server.execute("route_location", { name: "invalid_path" })
+    assert_nil response[:result]
+  end
 end


### PR DESCRIPTION
This PR adds support for the Definition request for Rails routes.

The implementation is based on @tenderlove's prototype in https://github.com/tenderlove/refreshing, and uses the behaviour added by @luanzeba and others in https://github.com/rails/rails/pull/47877.

Notes:

- For Sorbet projects using the Tapioca DSL generators for routes, the Definition Lookup will return two results - one for the RBI file, and one for the actual route.

- Unfortunately it doesn't work on Core, the source location always point to a `super` call in `routing_annotations.rb`. `bin/rails routes --expanded` has the same problem.

- There is some behaviour that might be a bug in VS Code:
If you double-click on a route name to select it, then choose Go To Definition, it works _only_ if the token has parenthesis on it, e.g. it works for `user_path(1)` but not `users_path`. But if you right click on `users_path` without selecting it, it works fine.


TODO:

- [x] confirm there is minimal performance impact for apps with a large number of routes
- [x] verify it doesn't break on older versions of Rails

# Testing

It's working well on Identity, (which doesn't use Sorbet) and Code DB (which does use Sorbet).