### PR TITLE
Fix version logging

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -3,6 +3,7 @@
 
 require "ruby_lsp/addon"
 
+require_relative "../../ruby_lsp_rails/version"
 require_relative "support/active_support_test_case_helper"
 require_relative "support/callbacks"
 require_relative "runner_client"


### PR DESCRIPTION
Prevent `VERSION` wrongly resolving to the one from ruby-lsp: https://github.com/Shopify/ruby-lsp/blob/main/lib/ruby-lsp.rb