### PR TITLE
Constrain sqlite3 gem for Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "puma"
-gem "sqlite3"
+gem "sqlite3", "< 2"
 gem "debug", ">= 1.7.0"
 gem "mocha"
 gem "rubocop-shopify", "~> 2.15", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,7 @@ DEPENDENCIES
   rubocop-sorbet (~> 0.8)
   ruby-lsp-rails!
   sorbet-static-and-runtime
-  sqlite3
+  sqlite3 (< 2)
   tapioca (~> 0.13)
   webmock
 

--- a/gemfiles/Gemfile-rails-main
+++ b/gemfiles/Gemfile-rails-main
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec path: ".."
 
 gem "puma"
-gem "sqlite3"
+gem "sqlite3", "< 2"
 gem "debug", ">= 1.7.0"
 gem "mocha"
 gem "rubocop-shopify", "~> 2.14", require: false


### PR DESCRIPTION
The v2.0.0 release of the [sqlite3 gem](https://rubygems.org/gems/sqlite3) today seems to be causing some issues with Rails ([example](https://github.com/Shopify/ruby-lsp-rails/actions/runs/8727205571/job/23944218243)). Let's temporarily constrain it until that is resolved.