### PR TITLE
Exclude sqlite3 from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - "sqlite3"


### PR DESCRIPTION
v2 of the sqlite3 gem is not compatible with Rails 7.1.