### PR TITLE
Prefix `bin/rails` with `ruby` on Windows

### DIFF
--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -263,6 +263,16 @@ module RubyLsp
         assert_empty(data)
       end
 
+      test "prefixes the binstub call with `ruby` on Windows" do
+        Gem.stubs(:win_platform?).returns(true)
+        response = generate_code_lens_for_source(<<~RUBY)
+          class Test < ActiveSupport::TestCase
+          end
+        RUBY
+
+        assert_equal("ruby bin/rails test /fake.rb", response[0].command.arguments[2])
+      end
+
       private
 
       def generate_code_lens_for_source(source)


### PR DESCRIPTION
As discussed in https://github.com/Shopify/ruby-lsp-rails/issues/351, and documented [here](https://guides.rubyonrails.org/getting_started.html#starting-up-the-web-server), we should prefix the `bin/rails` call with `ruby` on Windows.