### PR TITLE
Temporarily skip another test on Windows

### DIFF
--- a/test/ruby_lsp_rails/definition_test.rb
+++ b/test/ruby_lsp_rails/definition_test.rb
@@ -3,6 +3,9 @@
 
 require "test_helper"
 
+# tests are hanging in CI. https://github.com/Shopify/ruby-lsp-rails/issues/364
+return if Gem.win_platform?
+
 module RubyLsp
   module Rails
     class DefinitionTest < ActiveSupport::TestCase

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -4,7 +4,7 @@
 require "test_helper"
 require "ruby_lsp/ruby_lsp_rails/runner_client"
 
-# tests are hanging in CI. https://github.com/Shopify/ruby-lsp-rails/issues/348
+# tests are hanging in CI. https://github.com/Shopify/ruby-lsp-rails/issues/364
 return if Gem.win_platform?
 
 module RubyLsp


### PR DESCRIPTION
https://github.com/Shopify/ruby-lsp-rails/pull/352 was passing but since it was behind `main`, there were some failures it once it was merged.

Once https://github.com/Shopify/ruby-lsp-rails/issues/364 is solved, we can remove this.