### PR TITLE
Set up DB for tests as part of default Rake task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           cache-version: 7
 
       - name: Run tests
-        run: bundle exec rails db:setup && bundle exec rails db:migrate && bundle exec rails test
+        run: bundle exec rake
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -30,4 +30,4 @@ end
 
 RubyLsp::CheckDocs.new(FileList["#{__dir__}/lib/ruby_lsp/**/*.rb"], FileList["#{__dir__}/misc/**/*.gif"])
 
-task default: :test
+task default: [:"db:setup", :test]


### PR DESCRIPTION
The first time someone cloned and runs the tests, they'll get a confusing error because the dB doesn't yet exist.

I originally considered checking if the DB exists first, but creating is very quick so I don't think that's necessary.

(for sqlite3 at least, `db:setup` is idempotent so there's no problem with it being re-run. We don't care about the data in the DB).