### PR TITLE
Drop Ruby 3.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,10 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/Gemfile-rails-main
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
         include:
           - gemfile: "gemfiles/Gemfile-rails-main"
             experimental: true
-        exclude:
-          - os: "windows-latest"
-            ruby: "3.0"
-          - Gemfile: "gemfiles/Gemfile-rails-main" # needs Ruby 3.1
-            ruby: "3.0"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:


### PR DESCRIPTION
Ruby 3.0 is EOL as of 23 Apr 2024

We already dropped in ruby-lsp: https://github.com/Shopify/ruby-lsp/pull/2017