### PR TITLE
Remove explicit dependence on sorbet-runtime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ PATH
   specs:
     ruby-lsp-rails (0.3.6)
       ruby-lsp (>= 0.17.0, < 0.18.0)
-      sorbet-runtime (>= 0.5.9897)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-lsp-rails.gemspec
+++ b/ruby-lsp-rails.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency("ruby-lsp", ">= 0.17.0", "< 0.18.0")
-  spec.add_dependency("sorbet-runtime", ">= 0.5.9897")
 end


### PR DESCRIPTION
Since we already depend on `sorbet-runtime` via `ruby-lsp`, I don't think there's any need to have it here.