### PR TITLE
Use NodeContext from RubyLSP to fix Definition targetting

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/definition.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/definition.rb
@@ -52,17 +52,18 @@ module RubyLsp
 
       sig { params(node: Prism::SymbolNode).void }
       def on_symbol_node_enter(node)
-        handle_dsl(node) if @node_context.call_node
+        handle_possible_dsl(node)
       end
 
       sig { params(node: Prism::StringNode).void }
       def on_string_node_enter(node)
-        handle_dsl(node) if @node_context.call_node
+        handle_possible_dsl(node)
       end
 
       sig { params(node: T.any(Prism::SymbolNode, Prism::StringNode)).void }
-      def handle_dsl(node)
-        node = T.must(@node_context.call_node)
+      def handle_possible_dsl(node)
+        node = @node_context.call_node
+        return unless node
         return unless self_receiver?(node)
 
         message = node.message

--- a/test/ruby_lsp_rails/definition_test.rb
+++ b/test/ruby_lsp_rails/definition_test.rb
@@ -7,7 +7,7 @@ module RubyLsp
   module Rails
     class DefinitionTest < ActiveSupport::TestCase
       test "recognizes model callback with multiple symbol arguments" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 10 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 18 })
           # typed: false
 
           class TestModel
@@ -34,7 +34,7 @@ module RubyLsp
       end
 
       test "recognizes has_many model associations" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 4 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 14 })
           # typed: false
 
           class Organization < ActiveRecord::Base
@@ -53,7 +53,7 @@ module RubyLsp
       end
 
       test "recognizes belongs_to model associations" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 4 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 14 })
           # typed: false
 
           class Membership < ActiveRecord::Base
@@ -72,7 +72,7 @@ module RubyLsp
       end
 
       test "recognizes has_one model associations" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 4 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 11 })
           # typed: false
 
           class User < ActiveRecord::Base
@@ -91,7 +91,7 @@ module RubyLsp
       end
 
       test "recognizes has_and_belongs_to_many model associations" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 4 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 27 })
           # typed: false
 
           class Profile < ActiveRecord::Base
@@ -110,7 +110,7 @@ module RubyLsp
       end
 
       test "handles class_name argument for associations" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 4 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 11 })
           # typed: false
 
           class User < ActiveRecord::Base
@@ -129,7 +129,7 @@ module RubyLsp
       end
 
       test "recognizes controller callback with string argument" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 10 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 17 })
           # typed: false
 
           class TestController
@@ -149,7 +149,7 @@ module RubyLsp
       end
 
       test "recognizes job callback with string and symbol arguments" do
-        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 10 })
+        response = generate_definitions_for_source(<<~RUBY, { line: 3, character: 18 })
           # typed: false
 
           class TestJob


### PR DESCRIPTION
We made an [addition](https://github.com/Shopify/ruby-lsp/pull/2115/files) to Ruby LSP which to add call node information to `NodeContext`. This means we can now fix the Ruby LSP Rails beahavior for various DSL calls.

For example, previously when you had an association `has_many :widgets`, the Go To Definition feature would only work if triggered on the `has_many` token. Now it works for the `:widgets` token, as originally intended.