### PR TITLE
Recognize aliases for `after_commit`

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/support/callbacks.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/callbacks.rb
@@ -16,6 +16,10 @@ module RubyLsp
             "around_create",
             "after_create",
             "after_commit",
+            "after_create_commit", # alias for after_commit
+            "after_update_commit", # alias for after_commit
+            "after_destroy_commit", # alias for after_commit
+            "after_save_commit", # alias for after_commit
             "after_rollback",
             "before_update",
             "around_update",

--- a/lib/ruby_lsp/ruby_lsp_rails/support/callbacks.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/callbacks.rb
@@ -16,10 +16,10 @@ module RubyLsp
             "around_create",
             "after_create",
             "after_commit",
-            "after_create_commit", # alias for after_commit
-            "after_update_commit", # alias for after_commit
-            "after_destroy_commit", # alias for after_commit
-            "after_save_commit", # alias for after_commit
+            "after_create_commit",
+            "after_update_commit",
+            "after_destroy_commit",
+            "after_save_commit",
             "after_rollback",
             "before_update",
             "around_update",


### PR DESCRIPTION
See https://guides.rubyonrails.org/active_record_callbacks.html#aliases-for-after-commit