### PR TITLE
Prevent broken pipes leading to client errors

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -172,6 +172,8 @@ module RubyLsp
         json = message.to_json
 
         @stdin.write("Content-Length: #{json.length}\r\n\r\n", json)
+      rescue Errno::EPIPE
+        # The server connection died
       end
 
       alias_method :send_notification, :send_message
@@ -193,6 +195,9 @@ module RubyLsp
         end
 
         response.fetch(:result)
+      rescue Errno::EPIPE
+        # The server connection died
+        nil
       end
     end
 


### PR DESCRIPTION
If for any reason the server died and the pipes are broken, we cannot keep trying to write to STDIN or read from STDOUT because that will raise and halt the regular operation of the LSP.