### PR TITLE
Fix route code lens when there are no classes in the stack

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -160,8 +160,10 @@ module RubyLsp
 
       sig { returns(T.nilable(T::Boolean)) }
       def controller?
-        class_name, superclass_name = T.must(@constant_name_stack.last)
-        class_name.end_with?("Controller") && superclass_name&.end_with?("Controller")
+        class_name, superclass_name = @constant_name_stack.last
+        return false unless class_name && superclass_name
+
+        class_name.end_with?("Controller") && superclass_name.end_with?("Controller")
       end
 
       sig { params(node: Prism::DefNode).void }

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -303,6 +303,15 @@ module RubyLsp
         assert_match("config/routes.rb", path)
       end
 
+      test "doesn't break when analyzing a file without a class" do
+        response = generate_code_lens_for_source(<<~RUBY)
+          def index
+          end
+        RUBY
+
+        assert_empty(response)
+      end
+
       private
 
       attr_reader :ruby


### PR DESCRIPTION
We cannot assume that there will always be something in the class stack, because the user could be editing a method on the top level.