### PR TITLE
Use new open file argument format

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -169,32 +169,16 @@ module RubyLsp
       sig { params(node: Prism::DefNode).void }
       def add_route_code_lens_to_action(node)
         class_name, _ = T.must(@constant_name_stack.last)
-        route = @client.route(
-          controller: class_name,
-          action: node.name.to_s,
-        )
-
+        route = @client.route(controller: class_name, action: node.name.to_s)
         return unless route
 
-        path = route[:path]
-        verb = route[:verb]
-        source_location = route[:source_location]
-
-        arguments = [
-          source_location,
-          {
-            start_line: node.location.start_line - 1,
-            start_column: node.location.start_column,
-            end_line: node.location.end_line - 1,
-            end_column: node.location.end_column,
-          },
-        ]
+        file_path, line = route[:source_location]
 
         @response_builder << create_code_lens(
           node,
-          title: [verb, path].join(" "),
+          title: "#{route[:verb]} #{route[:path]}",
           command_name: "rubyLsp.openFile",
-          arguments: arguments,
+          arguments: [["file://#{file_path}#L#{line}"]],
           data: { type: "file" },
         )
       end

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -295,12 +295,11 @@ module RubyLsp
             end
           end
         RUBY
-        path, line = response[0].command.arguments.first
+        uri = response[0].command.arguments.first.first
 
         assert_equal(1, response.size)
         assert_match("GET /users(.:format)", response[0].command.title)
-        assert_equal("4", line)
-        assert_match("config/routes.rb", path)
+        assert_match("config/routes.rb#L4", uri)
       end
 
       test "doesn't break when analyzing a file without a class" do


### PR DESCRIPTION
Use the new open file format introduced in https://github.com/Shopify/ruby-lsp/pull/2312. Standardizing on that format means we can provide code lens for jumping to views as well.