### PR TITLE
Check test framework only before pushing test code lens

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -51,9 +51,7 @@ module RubyLsp
         ).void
       end
       def create_code_lens_listener(response_builder, uri, dispatcher)
-        return unless T.must(@global_state).test_library == "rails"
-
-        CodeLens.new(@client, response_builder, uri, dispatcher)
+        CodeLens.new(@client, T.must(@global_state), response_builder, uri, dispatcher)
       end
 
       sig do

--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -79,13 +79,15 @@ module RubyLsp
       sig do
         params(
           client: RunnerClient,
+          global_state: GlobalState,
           response_builder:  ResponseBuilders::CollectionResponseBuilder[Interface::CodeLens],
           uri: URI::Generic,
           dispatcher: Prism::Dispatcher,
         ).void
       end
-      def initialize(client, response_builder, uri, dispatcher)
+      def initialize(client, global_state, response_builder, uri, dispatcher)
         @client = client
+        @global_state = global_state
         @response_builder = response_builder
         @path = T.let(uri.to_standardized_path, T.nilable(String))
         @group_id = T.let(1, Integer)
@@ -230,6 +232,7 @@ module RubyLsp
       sig { params(node: Prism::Node, name: String, command: String, kind: Symbol).void }
       def add_test_code_lens(node, name:, command:, kind:)
         return unless @path
+        return unless @global_state.test_library == "rails"
 
         arguments = [
           @path,

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -312,6 +312,29 @@ module RubyLsp
         assert_empty(response)
       end
 
+      test "returns code lenses despite different test framework" do
+        RubyLsp::GlobalState.any_instance.stubs(:test_library).returns("rspec")
+
+        response = generate_code_lens_for_source(<<~RUBY)
+          class UsersController < ApplicationController
+            def index
+            end
+          end
+        RUBY
+
+        refute_empty(response)
+
+        response = generate_code_lens_for_source(<<~RUBY, file: "file://db/migrate/123456_add_first_name_to_users.rb")
+          class AddFirstNameToUsers < ActiveRecord::Migration[7.1]
+            def change
+              add_column(:users, :first_name, :string)
+            end
+          end
+        RUBY
+
+        refute_empty(response)
+      end
+
       private
 
       attr_reader :ruby


### PR DESCRIPTION
Closes #409

Move the test library check only before trying to create new test code lenses, so that the others are still displayed.