### PR TITLE
Add jump to view code lenses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
     rbi (0.1.13)
       prism (>= 0.18.0, < 1.0.0)
       sorbet-runtime (>= 0.5.9204)
-    rbs (3.5.1)
+    rbs (3.5.2)
       logger
     regexp_parser (2.9.0)
     reline (0.5.7)
@@ -232,7 +232,7 @@ GEM
       rubocop (~> 1.51)
     rubocop-sorbet (0.8.3)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.17.4)
+    ruby-lsp (0.17.7)
       language_server-protocol (~> 3.17.0)
       prism (>= 0.29.0, < 0.31)
       rbs (>= 3, < 4)

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -36,6 +36,9 @@ module RubyLsp
 
       extend T::Sig
 
+      sig { returns(String) }
+      attr_reader :rails_root
+
       sig { void }
       def initialize
         # Spring needs a Process session ID. It uses this ID to "attach" itself to the parent process, so that when the
@@ -67,7 +70,8 @@ module RubyLsp
 
         begin
           count += 1
-          read_response
+          initialize_response = T.must(read_response)
+          @rails_root = T.let(initialize_response[:root], String)
         rescue EmptyMessageError
           $stderr.puts("Ruby LSP Rails is retrying initialize (#{count})")
           retry if count < MAX_RETRIES
@@ -216,6 +220,11 @@ module RubyLsp
       sig { override.returns(T::Boolean) }
       def stopped?
         true
+      end
+
+      sig { override.returns(String) }
+      def rails_root
+        Dir.pwd
       end
 
       private

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -24,7 +24,7 @@ module RubyLsp
         routes_reloader = ::Rails.application.routes_reloader
         routes_reloader.execute_unless_loaded if routes_reloader&.respond_to?(:execute_unless_loaded)
 
-        initialize_result = { result: { message: "ok" } }.to_json
+        initialize_result = { result: { message: "ok", root: ::Rails.root.to_s } }.to_json
         $stdout.write("Content-Length: #{initialize_result.length}\r\n\r\n#{initialize_result}")
 
         while @running

--- a/test/dummy/app/views/users/index.html.erb
+++ b/test/dummy/app/views/users/index.html.erb
@@ -1,0 +1,1 @@
+<h1>User list!</h1>


### PR DESCRIPTION
Closes #384

This PR adds the ability to jump to related views from a controller action.

Implementation:

1. Updated the `ruby-lsp` just to get proper ERB support
2. Started returning the `Rails.root` from the server initialization response. We often need to know where the application exists from the addon side
3. Used the Root and the controller information to discover which views exist for a given action


https://github.com/user-attachments/assets/5d63445c-4352-47fb-aa3a-76ad45243c74