### PR TITLE
No need to delete `Gemfile.lock` in CI for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Remove Gemfile.lock
-        if: (matrix.gemfile == 'Gemfile') && (matrix.ruby == 'head' || matrix.os == 'windows-latest')
+        if: (matrix.gemfile == 'Gemfile') && (matrix.ruby == 'head')
         run: "rm ${{ matrix.gemfile }}.lock"
 
       - name: Set up Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.5-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -253,6 +255,7 @@ GEM
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
     sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x64-mingw-ucrt)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
     stringio (3.1.0)
@@ -270,6 +273,8 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2024.1)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)
@@ -287,6 +292,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x64-mingw-ucrt
   x86_64-darwin
   x86_64-linux
 


### PR DESCRIPTION
Since we dropped Ruby 3.0 this seems no longer necessary.