### PR TITLE
Fix markdown in Code Lens docs

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -51,7 +51,7 @@ module RubyLsp
     # class AddFirstNameToUsers < ActiveRecord::Migration[7.1]
     #   # ...
     # end
-    # ````
+    # ```
     #
     # The code lenses will be displayed above the class and above each test method.
     #


### PR DESCRIPTION
I noticed this was messed up on https://shopify.github.io/ruby-lsp-rails/RubyLsp/Rails/CodeLens.html