### PR TITLE
Account for dynamic constant paths in document symbol

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -151,7 +151,8 @@ module RubyLsp
               selection_range: range_from_location(argument.location),
             )
           when Prism::ConstantReadNode, Prism::ConstantPathNode
-            name = argument.full_name
+            name = constant_name(argument)
+            next unless name
             next if name.empty?
 
             append_document_symbol(

--- a/test/ruby_lsp_rails/document_symbol_test.rb
+++ b/test/ruby_lsp_rails/document_symbol_test.rb
@@ -415,6 +415,18 @@ module RubyLsp
         assert_equal("belongs_to :baz", response[0].children[1].name)
       end
 
+      test "does not break with incomplete constant path nodes" do
+        response = generate_document_symbols_for_source(<<~RUBY)
+          class FooModel < ApplicationRecord
+            validate var::Foo
+          end
+        RUBY
+
+        assert_equal(1, response.size)
+        assert_equal("FooModel", response[0].name)
+        assert_empty(response[0].children)
+      end
+
       private
 
       def generate_document_symbols_for_source(source)


### PR DESCRIPTION
Closes #436

We already have a helper to get a constant name safely, so we just need to use it and ensure we don't try to push symbols for constant that are incomplete in the middle of typing or that contain dynamic parts.