### PR TITLE
Avoid `setpgrp` if `setsid` fails

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -46,8 +46,8 @@ module RubyLsp
         # parent ends, the spring process ends as well. If this is not set, Spring will throw an error while trying to
         # set its own session ID
         begin
-          Process.setpgrp
           Process.setsid
+          Process.setpgrp
         rescue Errno::EPERM
           # If we can't set the session ID, continue
         rescue NotImplementedError


### PR DESCRIPTION
`setsid` throws [`EPERM`](https://man7.org/linux/man-pages/man2/setsid.2.html#ERRORS) if it's attempted for a process that's already a group leader. It is bound to fail if you run`setpgrp` before `setsid`. As a result, the `ruby-lsp` process goes into stopped state and the client waits forever for the booting to finish.