### PR TITLE
Use regex to filter test runs for multiple classes in the same file

### DIFF
--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -150,6 +150,23 @@ module RubyLsp
         assert_match("Debug", response[5].command.title)
       end
 
+      test "uses regex to filter test classes defined in the same file" do
+        response = generate_code_lens_for_source(<<~RUBY)
+          class FirstTest < ActiveSupport::TestCase
+            def test_example
+            end
+          end
+
+          class SecondTest < ActiveSupport::TestCase
+            def test_example
+            end
+          end
+        RUBY
+
+        assert_match("bin/rails test /fake.rb --name \"/FirstTest(#|::)/\"", response[0].command.arguments[2])
+        assert_match("bin/rails test /fake.rb --name \"/SecondTest(#|::)/\"", response[7].command.arguments[2])
+      end
+
       test "assigns the correct hierarchy to test structure" do
         response = generate_code_lens_for_source(<<~RUBY)
           class Test < ActiveSupport::TestCase


### PR DESCRIPTION
We're currently always running the entire file when you have multiple test classes in the same one. We should use the same name regex existing in the Ruby LSP to properly filter the exact class being executed.

I just brought the approach over and added a test.