### PR TITLE
Prevent migration code lens from failing in unsaved files

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -151,7 +151,7 @@ module RubyLsp
           @group_id += 1
         end
 
-        if superclass_name&.start_with?("ActiveRecord::Migration")
+        if @path && superclass_name&.start_with?("ActiveRecord::Migration")
           command = "#{migrate_command} VERSION=#{migration_version}"
           add_migrate_code_lens(node, name: class_name, command: command)
         end


### PR DESCRIPTION
Our code lens code assumes that migration files are already saved to disk, by running `File.basename(T.must(@path))`.

It seemed like a reasonable assumption, but judging by our error telemetry, it seems people will write unsaved migrations more often that I expected. We can't run a migration that wasn't saved yet, so we just need to ensure the code doesn't break.

**Note**: there's currently no way to test this because the `with_server` test helper assumes that the URI passed will exist on disk, which is a limitation of our helper. This means I can't pass an `untitled:Untitled-1` URI to reproduce the issue.

You can verify that the issue is fixed after this change by pasting this migration into an unsaved file.

```ruby
class CreateUsers < ActiveRecord::Migration[7.0]
  def change
    create_table(:users) do |t|
      t.string(:first_name)
      t.string(:last_name)
      t.integer(:age)

      t.timestamps
    end
  end
end
```