### PR TITLE
Set default output device to stderr

### DIFF
--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -134,4 +134,22 @@ class ServerTest < ActiveSupport::TestCase
     assert_equal "GET", result[:verb]
     assert_equal "/users(.:format)", result[:path]
   end
+
+  test "prints in the Rails application or server are automatically redirected to stderr" do
+    server = RubyLsp::Rails::Server.new
+
+    server.instance_eval do
+      def resolve_route_info(requirements)
+        puts "Hello"
+        super
+      end
+    end
+
+    stdout, stderr = capture_subprocess_io do
+      server.execute("route_info", { controller: "UsersController", action: "index" })
+    end
+
+    assert_empty(stdout)
+    assert_equal("Hello\n", stderr)
+  end
 end


### PR DESCRIPTION
This PR uses the same technique as https://github.com/Shopify/ruby-lsp/pull/2514 to set the default output device to stderr. The default output device (`$>`) is where implicit calls to IO methods like `puts` and `print` go.

If we grab a reference to all of the pipes ahead of time and then switch the output device, we can ensure that any `puts` in the code goes to stderr instead of breaking the communication with the client.

I think this will make the connection more robust, since prints in the user's Rails application will no longer impact our communication.