### PR TITLE
Allow server addons to write responses back

### DIFF
--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -144,7 +144,7 @@ class ServerTest < ActiveSupport::TestCase
         end
 
         def execute(request, params)
-          { request:, params: }
+          write_response({ request:, params: })
         end
       end
     RUBY


### PR DESCRIPTION
Following the same pattern as in #453, we shouldn't assume that everything returned by a server addon is always a response.

We should let the server addon decide when to write the response back and how many responses to write - especially if they are interested in doing logging or informing progress.

This PR changes the way server addon responses are returned to fit the async nature of LSPs better.