### PR TITLE
Stop testing against Ruby 3.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/Gemfile-rails-main
-        ruby: ["3.1", "3.2", "3.3"]
+        ruby: ["3.2", "3.3"]
         include:
           - gemfile: "gemfiles/Gemfile-rails-main"
             experimental: true


### PR DESCRIPTION
Rails 8 needs Ruby 3.2.