### PR TITLE
Split `ServerAddon` into new file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,4 @@ Sorbet/StrictSigil:
     - "**/*.rake"
     - "test/**/*.rb"
     - "lib/ruby_lsp/ruby_lsp_rails/server.rb" # we can't assume sorbet-runtime is available
+    - "lib/ruby_lsp/ruby_lsp_rails/server_addon.rb" # we can't assume sorbet-runtime is available

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -2,57 +2,13 @@
 # frozen_string_literal: true
 
 require "json"
+require_relative "server_addon"
 
 # NOTE: We should avoid printing to stderr since it causes problems. We never read the standard error pipe from the
 # client, so it will become full and eventually hang or crash. Instead, return a response with an `error` key.
 
 module RubyLsp
   module Rails
-    class ServerAddon
-      @server_addon_classes = []
-      @server_addons = {}
-
-      class << self
-        # We keep track of runtime server add-ons the same way we track other add-ons, by storing classes that inherit
-        # from the base one
-        def inherited(child)
-          @server_addon_classes << child
-          super
-        end
-
-        # Delegate `request` with `params` to the server add-on with the given `name`
-        def delegate(name, request, params)
-          @server_addons[name]&.execute(request, params)
-        end
-
-        # Instantiate all server addons and store them in a hash for easy access after we have discovered the classes
-        def finalize_registrations!(stdout)
-          until @server_addon_classes.empty?
-            addon = @server_addon_classes.shift.new(stdout)
-            @server_addons[addon.name] = addon
-          end
-        end
-      end
-
-      def initialize(stdout)
-        @stdout = stdout
-      end
-
-      # Write a response back. Can be used for sending notifications to the editor
-      def write_response(response)
-        json_response = response.to_json
-        @stdout.write("Content-Length: #{json_response.length}\r\n\r\n#{json_response}")
-      end
-
-      def name
-        raise NotImplementedError, "Not implemented!"
-      end
-
-      def execute(request, params)
-        raise NotImplementedError, "Not implemented!"
-      end
-    end
-
     class Server
       def initialize(stdout: $stdout, override_default_output_device: true)
         # Grab references to the original pipes so that we can change the default output device further down

--- a/lib/ruby_lsp/ruby_lsp_rails/server_addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server_addon.rb
@@ -1,69 +1,53 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
-
-require "sorbet-runtime"
+#
+# requiring sorbet-runtime in the server can lead to some problems, so this is untyped
+# https://github.com/Shopify/ruby-lsp-rails/pull/469#issuecomment-2391429546
 
 module RubyLsp
   module Rails
     class ServerAddon
-      extend T::Sig
-      extend T::Helpers
-
-      abstract!
-
-      @server_addon_classes = T.let([], T::Array[T.class_of(ServerAddon)])
-      @server_addons = T.let({}, T::Hash[String, ServerAddon])
-
-      module Types
-        Params = T.type_alias { T::Hash[T.untyped, T.untyped] }
-        Response = T.type_alias { T::Hash[Symbol, T.untyped] }
-      end
+      @server_addon_classes = []
+      @server_addons = {}
 
       class << self
-        extend T::Sig
-
         # We keep track of runtime server add-ons the same way we track other add-ons, by storing
         # classes that inherit from the base one
-        sig { params(child: T::Class[T.anything]).void }
         def inherited(child)
-          @server_addon_classes << T.cast(child, T.class_of(ServerAddon))
+          @server_addon_classes << child
           super
         end
 
         # Delegate `request` with `params` to the server add-on with the given `name`
-        sig { params(name: String, request: String, params: Types::Params).returns(T.nilable(Types::Response)) }
         def delegate(name, request, params)
           @server_addons[name]&.execute(request, params)
         end
 
         # Instantiate all server addons and store them in a hash for easy access after we have discovered the classes
-        sig { params(stdout: T.any(IO, StringIO)).void }
         def finalize_registrations!(stdout)
           until @server_addon_classes.empty?
-            addon = T.must(@server_addon_classes.shift).new(stdout)
+            addon = @server_addon_classes.shift.new(stdout)
             @server_addons[addon.name] = addon
           end
         end
       end
 
-      sig { params(stdout: T.any(IO, StringIO)).void }
       def initialize(stdout)
         @stdout = stdout
       end
 
       # Write a response back. Can be used for sending notifications to the editor
-      sig { params(response: Types::Response).void }
       def write_response(response)
         json_response = response.to_json
         @stdout.write("Content-Length: #{json_response.length}\r\n\r\n#{json_response}")
       end
 
-      sig { abstract.returns(String) }
       def name
+        raise NotImplementedError, "Not implemented!"
       end
 
-      sig { abstract.params(request: String, params: Types::Params).returns(Types::Response) }
       def execute(request, params)
+        raise NotImplementedError, "Not implemented!"
       end
     end
   end

--- a/lib/ruby_lsp/ruby_lsp_rails/server_addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server_addon.rb
@@ -1,6 +1,6 @@
 # typed: false
 # frozen_string_literal: true
-#
+
 # requiring sorbet-runtime in the server can lead to some problems, so this is untyped
 # https://github.com/Shopify/ruby-lsp-rails/pull/469#issuecomment-2391429546
 

--- a/lib/ruby_lsp/ruby_lsp_rails/server_addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server_addon.rb
@@ -1,0 +1,70 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module RubyLsp
+  module Rails
+    class ServerAddon
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
+      @server_addon_classes = T.let([], T::Array[T.class_of(ServerAddon)])
+      @server_addons = T.let({}, T::Hash[String, ServerAddon])
+
+      module Types
+        Params = T.type_alias { T::Hash[T.untyped, T.untyped] }
+        Response = T.type_alias { T::Hash[Symbol, T.untyped] }
+      end
+
+      class << self
+        extend T::Sig
+
+        # We keep track of runtime server add-ons the same way we track other add-ons, by storing
+        # classes that inherit from the base one
+        sig { params(child: T::Class[T.anything]).void }
+        def inherited(child)
+          @server_addon_classes << T.cast(child, T.class_of(ServerAddon))
+          super
+        end
+
+        # Delegate `request` with `params` to the server add-on with the given `name`
+        sig { params(name: String, request: String, params: Types::Params).returns(T.nilable(Types::Response)) }
+        def delegate(name, request, params)
+          @server_addons[name]&.execute(request, params)
+        end
+
+        # Instantiate all server addons and store them in a hash for easy access after we have discovered the classes
+        sig { params(stdout: T.any(IO, StringIO)).void }
+        def finalize_registrations!(stdout)
+          until @server_addon_classes.empty?
+            addon = T.must(@server_addon_classes.shift).new(stdout)
+            @server_addons[addon.name] = addon
+          end
+        end
+      end
+
+      sig { params(stdout: T.any(IO, StringIO)).void }
+      def initialize(stdout)
+        @stdout = stdout
+      end
+
+      # Write a response back. Can be used for sending notifications to the editor
+      sig { params(response: Types::Response).void }
+      def write_response(response)
+        json_response = response.to_json
+        @stdout.write("Content-Length: #{json_response.length}\r\n\r\n#{json_response}")
+      end
+
+      sig { abstract.returns(String) }
+      def name
+      end
+
+      sig { abstract.params(request: String, params: Types::Params).returns(Types::Response) }
+      def execute(request, params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- ~~It is able to benefit from `strict` typing now~~ removed because of some runtime problems
- It simplifies `server.rb`
- It is now possible to `require` it specifically in other files, eg if you want to write tests for your server addon, you can `require` the server addon file specifically

I originially had some other changes here too, but there are no longer needed!