### PR TITLE
Ensure schema link is rendered with column information

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -62,8 +62,8 @@ module RubyLsp
         schema_file = model[:schema_file]
 
         @response_builder.push(
-          "[Schema](#{URI::Generic.from_path(path: schema_file)})",
-          category: :links,
+          "[Schema](#{URI::Generic.from_path(path: schema_file)})\n",
+          category: :documentation,
         ) if schema_file
 
         @response_builder.push(

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -35,8 +35,9 @@ module RubyLsp
           ```
 
           **Definitions**: [fake.rb](file:///fake.rb#L1,1-2,4)
-          [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
+
+          [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
           **id**: integer (PK)
 
@@ -83,8 +84,9 @@ module RubyLsp
           ```
 
           **Definitions**: [fake.rb](file:///fake.rb#L2,3-3,6)
-          [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
+
+          [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
           **id**: integer (PK)
 
@@ -128,8 +130,9 @@ module RubyLsp
           ```
 
           **Definitions**: [fake.rb](file:///fake.rb#L1,1-2,4)
-          [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
+
+          [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
           **order_id**: integer (PK)
 


### PR DESCRIPTION
I noticed that after #472 the schema link was being rendered in the wrong place. In fact, it shouldn't be categorized as `link` because then the information may be separated from the column information, which is a bit weird.

I moved it as part of documentation and ensured that the line breaks made it render in the expected order.