### PR TITLE
Add delegate notification API

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -184,6 +184,16 @@ module RubyLsp
       sig { params(request: String, params: T.nilable(T::Hash[Symbol, T.untyped])).void }
       def send_notification(request, params = nil) = send_message(request, params)
 
+      sig { params(server_addon_name: String, request_name: String, params: T::Hash[Symbol, T.untyped]).void }
+      def send_delegate_notification(server_addon_name:, request_name:, params: {})
+        send_notification(
+          "server_addon/delegate",
+          server_addon_name: server_addon_name,
+          request_name: request_name,
+          params: params,
+        )
+      end
+
       private
 
       sig { overridable.params(request: String, params: T.nilable(T::Hash[Symbol, T.untyped])).void }


### PR DESCRIPTION
I went with kwargs for all, it differs from `send_notification` this way but I think it's clearer than positional args.