### PR TITLE
Fix dynamic constant path names in document symbol

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -141,7 +141,7 @@ module RubyLsp
 
             arg_receiver = argument.receiver
 
-            name = arg_receiver.full_name if arg_receiver.is_a?(Prism::ConstantReadNode) ||
+            name = constant_name(arg_receiver) if arg_receiver.is_a?(Prism::ConstantReadNode) ||
               arg_receiver.is_a?(Prism::ConstantPathNode)
             next unless name
 
@@ -201,8 +201,8 @@ module RubyLsp
         arguments.each do |argument|
           case argument
           when Prism::ConstantReadNode, Prism::ConstantPathNode
-            name = argument.full_name
-            next if name.empty?
+            name = constant_name(argument)
+            next unless name
 
             append_document_symbol(
               name: "#{message} #{name}",

--- a/test/ruby_lsp_rails/document_symbol_test.rb
+++ b/test/ruby_lsp_rails/document_symbol_test.rb
@@ -400,6 +400,18 @@ module RubyLsp
         assert_equal("validates_with Foo::BarClass", response[0].children[1].name)
       end
 
+      test "handles dynamic constant paths" do
+        response = generate_document_symbols_for_source(<<~RUBY)
+          class FooModel < ApplicationRecord
+            validates_with self::FooClass
+          end
+        RUBY
+
+        assert_equal(1, response.size)
+        assert_equal("FooModel", response[0].name)
+        assert_empty(response[0].children)
+      end
+
       test "correctly handles association callbacks with string and symbol argument types" do
         response = generate_document_symbols_for_source(<<~RUBY)
           class FooModel < ApplicationRecord


### PR DESCRIPTION
We need to always use the `constant_name` helper to get a constant path full name. If there are dynamic or missing parts, `full_name` raises.