### PR TITLE
Fix exception output capturing

### DIFF
--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -127,7 +127,7 @@ module RubyLsp
             end
 
             def execute(request, params)
-              debug_message("Hello!")
+              log_message("Hello!")
               send_message({ request:, params: })
             end
           end


### PR DESCRIPTION
Closes https://github.com/Shopify/team-ruby-dx/issues/1297

This ensure the failure output can be displayed in the Ruby LSP output panel.

To 🎩 :

* `dev down` on Core
* Save a model to trigger and RBI update
* Observe that the Ruby LSP output panel shows the appropriate error.

Note: Failures that were previously silent, such as hovering over a ActiveRecord model when the DB isn't set up, will now show in the logs.