### PR TITLE
Only invoke route.source_location if available

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -146,8 +146,10 @@ module RubyLsp
           ::Rails.application.routes.routes.find { |route| route.requirements == requirements }
         end
 
-        if route&.source_location
-          file, _, line = route.source_location.rpartition(":")
+        source_location = route&.respond_to?(:source_location) && route.source_location
+
+        if source_location
+          file, _, line = source_location.rpartition(":")
           body = {
             source_location: [::Rails.root.join(file).to_s, line],
             verb: route.verb,


### PR DESCRIPTION
Fix for #488

Since the Rails add-on is installed by default, while we don't aim to have every feature work on EOL versions of Rails, we still need to ensure we don't break. The `source_location` method only exists after 7.0.

It would be nice to generalize a solution for handling which features are available based on Rails version. Rather than checking with `respond_to?` on the server side every time, we can avoid the request to the server completely if we keep some sort of feature dictionary. Something like

```ruby
SERVER_FEATURE_VERSIONS = {
  route_locations: "7.1",
  some_other_thing: "8.0",
}
```