### PR TITLE
Add default and null info on hover

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -67,12 +67,27 @@ module RubyLsp
         ) if schema_file
 
         @response_builder.push(
-          model[:columns].map do |name, type|
+          model[:columns].map do |name, type, default_string, null|
             primary_key_suffix = " (PK)" if model[:primary_keys].include?(name)
-            "**#{name}**: #{type}#{primary_key_suffix}\n"
+            suffixes = []
+            suffixes << "default: #{format_default(default_string, type)}" if default_string
+            suffixes << "not null" unless null
+            suffix_string = " - #{suffixes.join(" - ")}" if suffixes.any?
+            "**#{name}**: #{type}#{primary_key_suffix}#{suffix_string}\n"
           end.join("\n"),
           category: :documentation,
         )
+      end
+
+      sig { params(default_string: String, type: String).returns(String) }
+      def format_default(default_string, type)
+        if type == "boolean"
+          default_string == "true" ? "TRUE" : "FALSE"
+        elsif type == "string"
+          default_string.inspect
+        else
+          default_string
+        end
       end
     end
   end

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -200,7 +200,7 @@ module RubyLsp
 
         info = {
           result: {
-            columns: const.columns.map { |column| [column.name, column.type] },
+            columns: const.columns.map { |column| [column.name, column.type, column.default, column.null] },
             primary_keys: Array(const.primary_key),
           },
         }

--- a/test/dummy/db/migrate/20241025225348_add_defaults_to_user.rb
+++ b/test/dummy/db/migrate/20241025225348_add_defaults_to_user.rb
@@ -1,0 +1,7 @@
+class AddDefaultsToUser < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :users, :age, from: nil, to: 0
+    add_column :users, :active, :boolean, default: true, null: false
+    change_column_default :users, :first_name, from: nil, to: ""
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_21_183200) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_25_225348) do
   create_table "composite_primary_keys", primary_key: ["order_id", "product_id"], force: :cascade do |t|
     t.integer "order_id"
     t.integer "product_id"
@@ -48,12 +48,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_21_183200) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "first_name"
+    t.string "first_name", default: ""
     t.string "last_name"
-    t.integer "age"
+    t.integer "age", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "country_id", null: false
+    t.boolean "active", default: true, null: false
     t.index ["country_id"], name: "index_users_on_country_id"
   end
 

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -10,12 +10,14 @@ module RubyLsp
         expected_response = {
           schema_file: "#{dummy_root}/db/schema.rb",
           columns: [
-            ["id", "integer"],
-            ["first_name", "string"],
-            ["last_name", "string"],
-            ["age", "integer"],
-            ["created_at", "datetime"],
-            ["updated_at", "datetime"],
+            ["id", "integer", nil, false],
+            ["first_name", "string", "", true],
+            ["last_name", "string", nil, true],
+            ["age", "integer", "0", true],
+            ["created_at", "datetime", nil, false],
+            ["updated_at", "datetime", nil, false],
+            ["country_id", "integer", nil, false],
+            ["active", "boolean", "true", false],
           ],
           primary_keys: ["id"],
         }
@@ -39,17 +41,21 @@ module RubyLsp
 
           [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
-          **id**: integer (PK)
+          **id**: integer (PK) - not null
 
-          **first_name**: string
+          **first_name**: string - default: ""
 
           **last_name**: string
 
-          **age**: integer
+          **age**: integer - default: 0
 
-          **created_at**: datetime
+          **created_at**: datetime - not null
 
-          **updated_at**: datetime
+          **updated_at**: datetime - not null
+
+          **country_id**: integer - not null
+
+          **active**: boolean - default: TRUE - not null
         CONTENT
       end
 
@@ -57,12 +63,14 @@ module RubyLsp
         expected_response = {
           schema_file: "#{dummy_root}/db/schema.rb",
           columns: [
-            ["id", "integer"],
-            ["first_name", "string"],
-            ["last_name", "string"],
-            ["age", "integer"],
-            ["created_at", "datetime"],
-            ["updated_at", "datetime"],
+            ["id", "integer", nil, false],
+            ["first_name", "string", "", true],
+            ["last_name", "string", nil, true],
+            ["age", "integer", "0", true],
+            ["created_at", "datetime", nil, false],
+            ["updated_at", "datetime", nil, false],
+            ["country_id", "integer", nil, false],
+            ["active", "boolean", "true", false],
           ],
           primary_keys: ["id"],
         }
@@ -88,17 +96,21 @@ module RubyLsp
 
           [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
-          **id**: integer (PK)
+          **id**: integer (PK) - not null
 
-          **first_name**: string
+          **first_name**: string - default: ""
 
           **last_name**: string
 
-          **age**: integer
+          **age**: integer - default: 0
 
-          **created_at**: datetime
+          **created_at**: datetime - not null
 
-          **updated_at**: datetime
+          **updated_at**: datetime - not null
+
+          **country_id**: integer - not null
+
+          **active**: boolean - default: TRUE - not null
         CONTENT
       end
 
@@ -134,15 +146,15 @@ module RubyLsp
 
           [Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})
 
-          **order_id**: integer (PK)
+          **order_id**: integer (PK) - not null
 
-          **product_id**: integer (PK)
+          **product_id**: integer (PK) - not null
 
-          **note**: string
+          **note**: string - not null
 
-          **created_at**: datetime
+          **created_at**: datetime - not null
 
-          **updated_at**: datetime
+          **updated_at**: datetime - not null
         CONTENT
       end
 

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -26,13 +26,14 @@ module RubyLsp
       test "#model returns information for the requested model" do
         # These columns are from the schema in the dummy app: test/dummy/db/schema.rb
         columns = [
-          ["id", "integer"],
-          ["first_name", "string"],
-          ["last_name", "string"],
-          ["age", "integer"],
-          ["created_at", "datetime"],
-          ["updated_at", "datetime"],
-          ["country_id", "integer"],
+          ["id", "integer", nil, false],
+          ["first_name", "string", "", true],
+          ["last_name", "string", nil, true],
+          ["age", "integer", "0", true],
+          ["created_at", "datetime", nil, false],
+          ["updated_at", "datetime", nil, false],
+          ["country_id", "integer", nil, false],
+          ["active", "boolean", "1", false],
         ]
         response = T.must(@client.model("User"))
         assert_equal(columns, response.fetch(:columns))


### PR DESCRIPTION
We plan to get ride of annotate to only use Ruby LSD in my company. The only missing thing for us is displaying defaults and null information for the model on hover.

This small PR tries to solves this problem.

![CleanShot 2024-10-26 at 01 35 52@2x](https://github.com/user-attachments/assets/771cad70-4cf8-4534-abf1-a67a68e66a50)

Please let me know if it needs improvements 🙂
