### PR TITLE
Return `nil` on empty response

### DIFF
--- a/test/ruby_lsp_rails/launch_test.rb
+++ b/test/ruby_lsp_rails/launch_test.rb
@@ -1,0 +1,27 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyLsp
+  module Rails
+    class LaunchTest < ActiveSupport::TestCase
+      test "launching the client succeeds" do
+        outgoing_queue = Thread::Queue.new
+
+        client = RunnerClient.create_client(outgoing_queue)
+        refute_instance_of(NullClient, client)
+
+        first = pop_log_notification(outgoing_queue, Constant::MessageType::LOG)
+        assert_equal("Ruby LSP Rails booting server", first.params.message)
+
+        second = pop_log_notification(outgoing_queue, Constant::MessageType::LOG)
+        assert_match("Finished booting Ruby LSP Rails server", second.params.message)
+
+        client.shutdown
+        assert_predicate(client, :stopped?)
+        outgoing_queue.close
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,5 +48,13 @@ module ActiveSupport
       )
       T.cast(result, RubyLsp::Result)
     end
+
+    def pop_log_notification(message_queue, type)
+      log = message_queue.pop
+      return log if log.params.type == type
+
+      log = message_queue.pop until log.params.type == type
+      log
+    end
   end
 end


### PR DESCRIPTION
We are currently raising if something is printed to stdout from the server and it results in an empty message, but I'm not sure why we were raising in the first place.

This keeps filling up our telemetry with errors that aren't actionable. It could be that the application printed something, but since there's no content, I think it's okay to just return `nil` (since this method is already expected to be able to return `nil`).