### PR TITLE
Add support for checking for pending migrations and running them

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -187,6 +187,29 @@ module RubyLsp
         )
       end
 
+      sig { returns(T.nilable(String)) }
+      def pending_migrations_message
+        response = make_request("pending_migrations_message")
+        response[:pending_migrations_message] if response
+      rescue IncompleteMessageError
+        log_message(
+          "Ruby LSP Rails failed when checking for pending migrations",
+          type: RubyLsp::Constant::MessageType::ERROR,
+        )
+        nil
+      end
+
+      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      def run_migrations
+        make_request("run_migrations")
+      rescue IncompleteMessageError
+        log_message(
+          "Ruby LSP Rails failed to run migrations",
+          type: RubyLsp::Constant::MessageType::ERROR,
+        )
+        nil
+      end
+
       # Delegates a request to a server add-on
       sig do
         params(


### PR DESCRIPTION
Add the ability to check for pending migrations and run them through the Rails runner client.

For checking if something is pending, we use the Rails API directly, which raises if there are any pending migrations.

For running them, we can't do it in process. The code that runs migrations is not designed to be invoked repeatedly and uses `load`, which means that we could end up with a memory bloat. I used `Open3.capture2` to run in a child process and grab the results.