### PR TITLE
Remove usage of present? from hover

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -71,7 +71,7 @@ module RubyLsp
             primary_key_suffix = " (PK)" if model[:primary_keys].include?(name)
             suffixes = []
             suffixes << "default: #{format_default(default_value, type)}" if default_value
-            suffixes << "not null" unless nullable || primary_key_suffix.present?
+            suffixes << "not null" unless nullable || primary_key_suffix
             suffix_string = " - #{suffixes.join(" - ")}" if suffixes.any?
             "**#{name}**: #{type}#{primary_key_suffix}#{suffix_string}\n"
           end.join("\n"),


### PR DESCRIPTION
We cannot use `present?` in the add-on side of the code because that method is defined by `activesupport` and that gem is not required on the LSP side.

It's only safe to use it in the runtime server side. This is currently breaking hover.

Note: tests won't catch this because in tests the Rails context is loaded through the dummy application, which makes tests pass despite this code breaking every time in real scenarios.