### PR TITLE
Unify all error handling for the server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rubyLsp.indexing": {
+        "includedPatterns": [
+            "test/dummy/**/*.rb"
+        ]
+    }
+}

--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -200,22 +200,21 @@ class ServerTest < ActiveSupport::TestCase
 
   test "shows error if there is a database connection error" do
     @server.expects(:pending_migrations_message).raises(ActiveRecord::ConnectionNotEstablished)
+    @server.execute("pending_migrations_message", {})
 
-    _, stderr = capture_subprocess_io do
-      @server.execute("pending_migrations_message", {})
-    end
-    assert_equal(stderr, "Request pending_migrations_message failed because database connection was not established.\n")
-    assert_equal({ result: nil }, response)
+    assert_equal(
+      { error: "Request pending_migrations_message failed because database connection was not established." }, response
+    )
   end
 
   test "shows error if database does not exist" do
     @server.expects(:pending_migrations_message).raises(ActiveRecord::NoDatabaseError)
+    @server.execute("pending_migrations_message", {})
 
-    _, stderr = capture_subprocess_io do
-      @server.execute("pending_migrations_message", {})
-    end
-    assert_equal(stderr, "Request pending_migrations_message failed because the database does not exist.\n")
-    assert_equal({ result: nil }, response)
+    assert_equal(
+      { error: "Request pending_migrations_message failed because the database does not exist." },
+      response,
+    )
   end
 
   private


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp/issues/2886

We cannot use blanket rescue statements for the entire server because the behaviour for handling errors is different between requests and notifications.

For requests, we want to return `error: message` instead of the typicaly `result: something`. And for notifications, we cannot return anything, we can only log that an error occurred.

The approach that I took here is to create handlers that we can use both ourselves and in server add-ons, that provide appropriate error handling for requests or notifications.

I also created convenience  methods for returning responses or errors.