### PR TITLE
Remove redundant rescue in runner client

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -27,7 +27,7 @@ module RubyLsp
 
             NullClient.new
           end
-        rescue Errno::ENOENT, StandardError => e # rubocop:disable Lint/ShadowedException
+        rescue StandardError => e
           unless outgoing_queue.closed?
             outgoing_queue << RubyLsp::Notification.window_log_message(
               <<~MESSAGE.chomp,


### PR DESCRIPTION
`Errno::ENOENT` already inherits from `StandardError`, so there is no need to rescue it explicitly

```
> Errno::ENOENT.new.is_a?(StandardError)
=> true
```