### PR TITLE
Support migration output messages containing multibyte characters

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -281,7 +281,7 @@ module RubyLsp
         json = message.to_json
 
         @mutex.synchronize do
-          @stdin.write("Content-Length: #{json.length}\r\n\r\n", json)
+          @stdin.write("Content-Length: #{json.bytesize}\r\n\r\n", json)
         end
       rescue Errno::EPIPE
         # The server connection died

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -13,7 +13,7 @@ module RubyLsp
       # Write a message to the client. Can be used for sending notifications to the editor
       def send_message(message)
         json_message = message.to_json
-        @stdout.write("Content-Length: #{json_message.length}\r\n\r\n#{json_message}")
+        @stdout.write("Content-Length: #{json_message.bytesize}\r\n\r\n#{json_message}")
       end
 
       # Log a message to the editor's output panel

--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -217,6 +217,18 @@ class ServerTest < ActiveSupport::TestCase
     )
   end
 
+  test "send_message uses bytesize for content length with ASCII characters" do
+    @server.send(:send_message, { test: "hello" })
+    assert_equal "Content-Length: 16\r\n\r\n{\"test\":\"hello\"}", @stdout.string
+  end
+
+  test "send_message uses bytesize for content length with multibyte characters" do
+    @server.send(:send_message, { test: "こんにちは" }) # Japanese "hello"
+    expected = "Content-Length: 26\r\n\r\n"
+    expected += { test: "こんにちは" }.to_json.force_encoding(Encoding::ASCII_8BIT)
+    assert_equal expected, @stdout.string
+  end
+
   private
 
   def response


### PR DESCRIPTION
The Content-Length header should be the number of bytes in the JSON. Since we're operating in `binmode`, the encoding of the JSON will be `ASCII-8BIT`, so we can use the bytesize method to get the number of bytes.

I noticed this when the LSP crashed while running a migration. Turns out that out migration output contained multibyte characters, and that was breaking the the length of the content that was read. The JSON that was read would be truncated because the content-length that was read was [too short](https://github.com/Shopify/ruby-lsp-rails/blob/e28e268fbdcc5f75ec5193a7cc0b385fcbdeca7c/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb#L297).

The easiest way to reproduce the problem would be to test with this migration:
```
# frozen_string_literal: true
class Multibytes < ActiveRecord::Migration[7.1]
  def change
    up_only do
      say_with_time 'This message is using curly quotes “” and em-dashes —' do
        # This is a no-op migration to test multibyte characters in migration files
      end
    end
  end
end
```

The error looked like that:
```
Error processing : /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/json-2.7.2/lib/json/common.rb:220:in `parse': unexpected token at '{"result":{"message":"Successfully installed foreman-0.88.1\n1 gem installed\n== 20241210202137 Multibytes: migrating =======================================\n-- This message is using curly quotes “” and em-dashes —\n   -> 0.0000s\n== 20241210202137 Multibytes: migrated (0.0000s) ==============================\n\n","statu' (JSON::ParserError)
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/json-2.7.2/lib/json/common.rb:220:in `parse'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/bundler/gems/ruby-lsp-rails-6cba8681e701/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb:300:in `read_response'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/bundler/gems/ruby-lsp-rails-6cba8681e701/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb:268:in `make_request'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/bundler/gems/ruby-lsp-rails-6cba8681e701/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb:204:in `run_migrations'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/sorbet-runtime-0.5.11690/lib/types/private/methods/_methods.rb:279:in `bind_call'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/sorbet-runtime-0.5.11690/lib/types/private/methods/_methods.rb:279:in `block in _on_method_added'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/bundler/gems/ruby-lsp-rails-6cba8681e701/lib/ruby_lsp/ruby_lsp_rails/addon.rb:146:in `handle_window_show_message_response'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/sorbet-runtime-0.5.11690/lib/types/private/methods/_methods.rb:279:in `bind_call'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/sorbet-runtime-0.5.11690/lib/types/private/methods/_methods.rb:279:in `block in _on_method_added'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:1225:in `window_show_message_request'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:148:in `process_response'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:110:in `process_message'
	from /Users/louim/.local/share/mise/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.22.1/lib/ruby_lsp/base_server.rb:163:in `block in new_worker'
```

I also fixed the runner-client for the same symptoms. However, I'm not sure when that implementation of `send_message` is used and didn't find an easy way to add a test. Let me know if this part of the change is required.