### PR TITLE
Allow server to send asynchronous notifications to client

### DIFF
--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -128,7 +128,7 @@ module RubyLsp
 
             def execute(request, params)
               log_message("Hello!")
-              send_message({ request:, params: })
+              send_result({ request: request, params: params })
             end
           end
         RUBY
@@ -141,16 +141,16 @@ module RubyLsp
         # Finished booting server
         pop_log_notification(@outgoing_queue, RubyLsp::Constant::MessageType::LOG)
 
-        log = pop_log_notification(@outgoing_queue, RubyLsp::Constant::MessageType::LOG)
+        log = @outgoing_queue.pop
 
         # Sometimes we get warnings concerning deprecations and they mess up this expectation
         3.times do
-          unless log.params.message.match?(/Hello!/)
-            log = pop_log_notification(@outgoing_queue, RubyLsp::Constant::MessageType::LOG)
+          unless log.dig(:params, :message).match?(/Hello!/)
+            log = @outgoing_queue.pop
           end
         end
 
-        assert_match("Hello!", log.params.message)
+        assert_match("Hello!", log.dig(:params, :message))
       ensure
         FileUtils.rm("server_addon.rb")
       end


### PR DESCRIPTION
Previously, we were only allowing the server and its runtime add-ons to send simple strings to the stderr pipe, which would become log notifications.

To support initiating progress from the server, we will need to allow any type of LSP notification to be send asynchronously.

This PR changes our current logger thread to become a more general notifier thread, which will read any messages received from the server and push them to the outgoing queue.

To prevent creating a breaking change, I kept the `log_message` method, but changed it to build the right notification expected.