### PR TITLE
Show progress when reloading the Rails application

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -258,8 +258,10 @@ module RubyLsp
             send_result(run_migrations)
           end
         when "reload"
-          with_notification_error_handling(request) do
-            ::Rails.application.reloader.reload!
+          with_progress("rails-reload", "Reloading Ruby LSP Rails instance") do
+            with_notification_error_handling(request) do
+              ::Rails.application.reloader.reload!
+            end
           end
         when "route_location"
           with_request_error_handling(request) do


### PR DESCRIPTION
One of the slowest parts of DSL RBI generation in the Tapioca add-on is actually the fact that we're reloading the Rails app.

In addition to adding progress notifications there, let's also show the progress of reloading the app, so that the user knows what's going on.