### PR TITLE
Improve fault tolerance of addon delegation requests

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -174,11 +174,7 @@ module RubyLsp
         # Delegate `request` with `params` to the server add-on with the given `name`
         def delegate(name, request, params)
           addon = @server_addons.fetch(name) do
-            checker = DidYouMean::SpellChecker.new(dictionary: @server_addons.keys)
-            suggestions = checker.correct(name)
-            msg = "No extension with name #{name}."
-            msg += " Did you mean: #{options.join(" / ")}" if suggestions.any?
-            raise ServerAddon::MissingAddonError, msg
+            raise ServerAddon::MissingAddonError, "No extension with name #{name}"
           end
           addon.execute(request, params)
         end


### PR DESCRIPTION
Currently there is no error handling for `server_addon/delegate` requests - which I think makes sense on the whole (in line with comment `Do not wrap this in error handlers. Server add-ons need to have the flexibility to choose if they want to include a response or not as part of error handling, so a blanket approach is not appropriate.`).

However, I think there is just `one` case where I think a bit of error handling might be quite helpful - namely if the requested extension is not available. Currently, `@server_addons[name]&.execute(request, params)` swallows any typos or mis-registered servers - but IMO it should be an error with a clear message reported.

With the current `delegate_request` implementation in runner_client, `make_request` sends the `server_addon/delegate` message to the server, and then gets stuck waiting for a response (which isn't going to come, because `@server_addons[name]&.execute(request, params)` is nil) - if I'm understanding things correctly.

```ruby
      def delegate_request(server_addon_name:, request_name:, **params)
        make_request(
          "server_addon/delegate",
          server_addon_name: server_addon_name,
          request_name: request_name,
          **params,
        )
      rescue MessageError
        nil
      end
```

I'd be curious for any other opinions on this, and if it's of interest I can add some test cases (and/or any more polish)