### PR TITLE
Remove `extend T::Sig` calls

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -19,8 +19,6 @@ require_relative "indexing_enhancement"
 module RubyLsp
   module Rails
     class Addon < ::RubyLsp::Addon
-      extend T::Sig
-
       RUN_MIGRATIONS_TITLE = "Run Migrations"
 
       #: -> void

--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -72,7 +72,6 @@ module RubyLsp
     # Note: Complex routing configurations may not be supported.
     #
     class CodeLens
-      extend T::Sig
       include Requests::Support::Common
       include ActiveSupportTestCaseHelper
 

--- a/lib/ruby_lsp/ruby_lsp_rails/completion.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/completion.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Rails
     class Completion
-      extend T::Sig
       include Requests::Support::Common
 
       # @override

--- a/lib/ruby_lsp/ruby_lsp_rails/definition.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/definition.rb
@@ -28,7 +28,6 @@ module RubyLsp
     # - If using `constraints`, the route can only be found if the constraints are met.
     # - Changes to routes won't be picked up until the server is restarted.
     class Definition
-      extend T::Sig
       include Requests::Support::Common
 
       #: (RunnerClient client, RubyLsp::ResponseBuilders::CollectionResponseBuilder[(Interface::Location | Interface::LocationLink)] response_builder, NodeContext node_context, RubyIndexer::Index index, Prism::Dispatcher dispatcher) -> void

--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -9,7 +9,6 @@ module RubyLsp
     # request allows users to navigate between associations, validations, callbacks and ActiveSupport test cases with
     # VS Code's "Go to Symbol" feature.
     class DocumentSymbol
-      extend T::Sig
       include Requests::Support::Common
       include ActiveSupportTestCaseHelper
 

--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -15,7 +15,6 @@ module RubyLsp
     # # ^ hovering here will show information about the User model
     # ```
     class Hover
-      extend T::Sig
       include Requests::Support::Common
 
       #: (RunnerClient client, ResponseBuilders::Hover response_builder, NodeContext node_context, GlobalState global_state, Prism::Dispatcher dispatcher) -> void

--- a/lib/ruby_lsp/ruby_lsp_rails/indexing_enhancement.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/indexing_enhancement.rb
@@ -4,8 +4,6 @@
 module RubyLsp
   module Rails
     class IndexingEnhancement < RubyIndexer::Enhancement
-      extend T::Sig
-
       # @override
       #: (Prism::CallNode call_node) -> void
       def on_call_node_enter(call_node)

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -8,8 +8,6 @@ module RubyLsp
   module Rails
     class RunnerClient
       class << self
-        extend T::Sig
-
         #: (Thread::Queue outgoing_queue, RubyLsp::GlobalState global_state) -> RunnerClient
         def create_client(outgoing_queue, global_state)
           if File.exist?("bin/rails")
@@ -45,8 +43,6 @@ module RubyLsp
       class InitializationError < StandardError; end
       class MessageError < StandardError; end
       class EmptyMessageError < MessageError; end
-
-      extend T::Sig
 
       #: String
       attr_reader :rails_root
@@ -368,8 +364,6 @@ module RubyLsp
     end
 
     class NullClient < RunnerClient
-      extend T::Sig
-
       #: -> void
       def initialize # rubocop:disable Lint/MissingSuper
       end

--- a/lib/ruby_lsp/ruby_lsp_rails/support/active_support_test_case_helper.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/active_support_test_case_helper.rb
@@ -4,8 +4,6 @@
 module RubyLsp
   module Rails
     module ActiveSupportTestCaseHelper
-      extend T::Sig
-
       #: (Prism::CallNode node) -> String?
       def extract_test_case_name(node)
         message_value = node.message

--- a/lib/ruby_lsp/ruby_lsp_rails/support/location_builder.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/location_builder.rb
@@ -6,8 +6,6 @@ module RubyLsp
     module Support
       class LocationBuilder
         class << self
-          extend T::Sig
-
           #: (String location_string) -> Interface::Location
           def line_location_from_s(location_string)
             *file_parts, line = location_string.split(":")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,6 @@ end
 
 module ActiveSupport
   class TestCase
-    extend T::Sig
     include RubyLsp::TestHelper
 
     def dummy_root


### PR DESCRIPTION
No longer needed with RBS