### PR TITLE
Enable static typechecking for server

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -387,13 +387,14 @@ module RubyLsp
         nil
       end
 
-      #: (const: singleton(ActiveRecord::Base)?) -> bool
+      #: (const: Module?) -> bool
       def active_record_model?(const)
         !!(
           const &&
             defined?(ActiveRecord) &&
             const.is_a?(Class) &&
             ActiveRecord::Base > const && # We do this 'backwards' in case the class overwrites `<`
+            const < ActiveRecord::Base && # this is just to narrow the type for Sorbet
           !const.abstract_class?
         )
       end

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "json"
@@ -380,11 +380,14 @@ module RubyLsp
         association_klass = const.reflect_on_association(params[:association_name].intern).klass
         source_location = Object.const_source_location(association_klass.to_s)
 
+        raise "Could not determine source location" unless source_location
+
         { location: source_location.first + ":" + source_location.second.to_s }
       rescue NameError
         nil
       end
 
+      #: (const: singleton(ActiveRecord::Base)?) -> bool
       def active_record_model?(const)
         !!(
           const &&

--- a/sorbet/rbi/shims/io_wrapper.rbi
+++ b/sorbet/rbi/shims/io_wrapper.rbi
@@ -1,0 +1,8 @@
+# typed: strict
+# frozen_string_literal: true
+
+class RubyLsp::Rails::IOWrapper
+  sig { params(message: String).void }
+  def write(message)
+  end
+end


### PR DESCRIPTION
Now that we have RBS signatures, we can enable typechecking for `server.rb`.