### PR TITLE
Add Rails test command resolution

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -93,6 +93,12 @@ module RubyLsp
         RailsTestStyle.new(@rails_runner_client, response_builder, @global_state, dispatcher, uri)
       end
 
+      # @override
+      #: (Array[Hash[Symbol, untyped]]) -> Array[String]
+      def resolve_test_commands(items)
+        RailsTestStyle.resolve_test_commands(items)
+      end
+
       # Creates a new CodeLens listener. This method is invoked on every CodeLens request
       # @override
       #: (ResponseBuilders::CollectionResponseBuilder[Interface::CodeLens] response_builder, URI::Generic uri, Prism::Dispatcher dispatcher) -> void

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -4,6 +4,52 @@
 module RubyLsp
   module Rails
     class RailsTestStyle < Listeners::TestDiscovery
+      BASE_COMMAND = "#{RbConfig.ruby} bin/rails test" #: String
+
+      class << self
+        #: (Array[Hash[Symbol, untyped]]) -> Array[String]
+        def resolve_test_commands(items)
+          commands = []
+          queue = items.dup
+
+          full_files = []
+
+          until queue.empty?
+            item = T.must(queue.shift)
+            tags = Set.new(item[:tags])
+            next unless tags.include?("framework:rails")
+
+            children = item[:children]
+            uri = URI(item[:uri])
+            path = uri.full_path
+            next unless path
+
+            if tags.include?("test_dir")
+              if children.empty?
+                full_files.concat(Dir.glob(
+                  "#{path}/**/{*_test,test_*}.rb",
+                  File::Constants::FNM_EXTGLOB | File::Constants::FNM_PATHNAME,
+                ))
+              end
+            elsif tags.include?("test_file")
+              full_files << path if children.empty?
+            elsif tags.include?("test_group")
+              commands << "#{BASE_COMMAND} #{path} --name \"/#{Shellwords.escape(item[:id])}(#|::)/\""
+            else
+              full_files << "#{path}:#{item.dig(:range, :start, :line) + 1}"
+            end
+
+            queue.concat(children)
+          end
+
+          unless full_files.empty?
+            commands << "#{BASE_COMMAND} #{full_files.join(" ")}"
+          end
+
+          commands
+        end
+      end
+
       #: (RunnerClient client, ResponseBuilders::TestCollection response_builder, GlobalState global_state, Prism::Dispatcher dispatcher, URI::Generic uri) -> void
       def initialize(client, response_builder, global_state, dispatcher, uri)
         super(response_builder, global_state, dispatcher, uri)

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -90,8 +90,9 @@ module RubyLsp
 
         test_name = first_arg.content
         test_name = "<empty test name>" if test_name.empty?
+        rails_normalized_name = "test_#{test_name.gsub(/\s+/, "_")}"
 
-        add_test_item(node, test_name)
+        add_test_item(node, rails_normalized_name)
       end
 
       #: (Prism::DefNode node) -> void

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -90,6 +90,10 @@ module RubyLsp
 
         test_name = first_arg.content
         test_name = "<empty test name>" if test_name.empty?
+
+        # Rails' `test "foo bar"` helper defines a method `def test_foo_bar`. We normalize test names
+        # the same way (spaces to underscores, prefix with `test_`) to match the actual method names
+        # Rails uses at runtime, ensuring proper test discovery and execution.
         rails_normalized_name = "test_#{test_name.gsub(/\s+/, "_")}"
 
         add_test_item(node, rails_normalized_name)

--- a/test/ruby_lsp_rails/rails_test_style_test.rb
+++ b/test/ruby_lsp_rails/rails_test_style_test.rb
@@ -26,8 +26,8 @@ module RubyLsp
           assert_equal(2, test_class[:children].length)
 
           test_labels = test_class[:children].map { |i| i[:label] }
-          assert_includes(test_labels, "first test")
-          assert_includes(test_labels, "second test")
+          assert_includes(test_labels, "test_first_test")
+          assert_includes(test_labels, "test_second_test")
           assert_all_items_tagged_with(items, :rails)
         end
       end
@@ -52,7 +52,7 @@ module RubyLsp
           assert_equal(2, test_class[:children].length)
 
           test_labels = test_class[:children].map { |i| i[:label] }
-          assert_includes(test_labels, "<empty test name>")
+          assert_includes(test_labels, "test_<empty_test_name>")
           assert_all_items_tagged_with(items, :rails)
         end
       end
@@ -110,11 +110,11 @@ module RubyLsp
       test "handles tests with special characters in name" do
         source = <<~RUBY
           class SpecialCharsTest < ActiveSupport::TestCase
-            test "test with spaces and punctuation!" do
+            test "spaces and punctuation!" do
               assert true
             end
 
-            test "test with unicode: 你好" do
+            test "unicode: 你好" do
               assert true
             end
           end
@@ -127,8 +127,8 @@ module RubyLsp
           assert_equal(2, test_class[:children].length)
 
           test_labels = test_class[:children].map { |i| i[:label] }
-          assert_includes(test_labels, "test with spaces and punctuation!")
-          assert_includes(test_labels, "test with unicode: 你好")
+          assert_includes(test_labels, "test_spaces_and_punctuation!")
+          assert_includes(test_labels, "test_unicode:_你好")
           assert_all_items_tagged_with(items, :rails)
         end
       end

--- a/test/ruby_lsp_rails/rails_test_style_test.rb
+++ b/test/ruby_lsp_rails/rails_test_style_test.rb
@@ -134,7 +134,12 @@ module RubyLsp
       end
 
       test "resolve test command entire files" do
-        Dir.stubs(:glob).returns(["/other/test/fake_test.rb", "/other/test/fake_test2.rb"])
+        base_dir = Gem.win_platform? ? "D:/other/test" : "/other/test"
+        test_paths = [
+          File.join(base_dir, "fake_test.rb"),
+          File.join(base_dir, "fake_test2.rb"),
+        ]
+        Dir.stubs(:glob).returns(test_paths)
 
         with_server do |server|
           sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
@@ -167,7 +172,7 @@ module RubyLsp
 
           assert_equal(
             [
-              "#{RailsTestStyle::BASE_COMMAND} /test/server_test.rb /other/test/fake_test.rb /other/test/fake_test2.rb",
+              "#{RailsTestStyle::BASE_COMMAND} /test/server_test.rb #{test_paths.join(" ")}",
             ],
             response[:commands],
           )


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp/issues/3179, closes https://github.com/Shopify/ruby-lsp/issues/3170

This PR builds on #591’s test discovery support by generating test commands for Rails tests discovered in VS Code’s Test Explorer.

**Before** 

Tests defined via `test "…"` appeared in the explorer, but clicking _Run_ did nothing as no command was emitted.

**After**

Now clicking _Run_ emits the exact `bin/rails test …` command Rails uses at runtime.

Added command resolution for:
- Directories: `Dir.glob` on `*_test.rb/test_*.rb`
- Files: individual test files
- Groups: named groups via `--name "/GroupTest(#|::)/"`
- Methods: single tests as `file:line` entries

For this to work, we normalize string-based test names (e.g., `"should do something"`) by prefixing `test_` and replacing spaces with underscores (`test_#{test_name.gsub(/\s+/, '_')}`), matching Rails' own `ActiveSupport::Testing::Declarative#test` helper. This ensures our test IDs line up with the methods Rails actually runs (e.g., `test_should_do_something`).

