### PR TITLE
Strip extra backslashes from discovered test names

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -88,7 +88,7 @@ module RubyLsp
         first_arg = arguments&.first
         return unless first_arg.is_a?(Prism::StringNode)
 
-        test_name = first_arg.content
+        test_name = first_arg.unescaped
         test_name = "<empty test name>" if test_name.empty?
 
         # Rails' `test "foo bar"` helper defines a method `def test_foo_bar`. We normalize test names

--- a/test/fixtures/test_with_escaped_quotes.rb
+++ b/test/fixtures/test_with_escaped_quotes.rb
@@ -1,0 +1,8 @@
+# typed: true
+# frozen_string_literal: true
+
+class SampleTest < ActiveSupport::TestCase
+  test "hello \"oh noes\"" do
+    assert true
+  end
+end

--- a/test/ruby_lsp_rails/rails_test_style_test.rb
+++ b/test/ruby_lsp_rails/rails_test_style_test.rb
@@ -228,6 +228,21 @@ module RubyLsp
         end
       end
 
+      test "tests with backslashes" do
+        source = File.read(File.join(__dir__, "..", "fixtures", "test_with_escaped_quotes.rb"))
+
+        with_active_support_declarative_tests(source) do |items|
+          assert_equal(1, items.length)
+          test_class = items.first
+          assert_equal("SampleTest", test_class[:label])
+          assert_equal(1, test_class[:children].length)
+
+          assert_equal(["SampleTest#test_hello_\"oh_noes\""], test_class[:children].map { |i| i[:id] })
+          assert_equal(["test_hello_\"oh_noes\""], test_class[:children].map { |i| i[:label] })
+          assert_all_items_tagged_with(items, :rails)
+        end
+      end
+
       private
 
       def with_active_support_declarative_tests(source, file: "/fake.rb", &block)


### PR DESCRIPTION
I found a bug while doing early testing of the explorer functionality in some Rails apps. We were having a test item ID mismatch (between discovered vs reported during execution) for tests that include a backslash.

If we have this scenario

```ruby
class MyTest < ActiveSupport::TestCase
  test "something \"escaped\"" do
  end
end
```

Prism reports the string node's content to be `something \\\"escaped\\\"`, which is the escaped version of the content (both the quote and the backslash itself are escaped).

We need to use `unescaped` to get the actual string without the extra escaping, so that we match the same ID reported during test execution.