### PR TITLE
Migrate to RBS in comments syntax

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/code_lens.rb
@@ -80,10 +80,10 @@ module RubyLsp
         @client = client
         @global_state = global_state
         @response_builder = response_builder
-        @path = T.let(uri.to_standardized_path, T.nilable(String))
-        @group_id = T.let(1, Integer)
-        @group_id_stack = T.let([], T::Array[Integer])
-        @constant_name_stack = T.let([], T::Array[[String, T.nilable(String)]])
+        @path = uri.to_standardized_path #: String?
+        @group_id = 1 #: Integer
+        @group_id_stack = [] #: Array[Integer]
+        @constant_name_stack = [] #: Array[[String, String?]]
 
         dispatcher.register(
           self,
@@ -209,7 +209,7 @@ module RubyLsp
 
       #: (Prism::DefNode node) -> void
       def add_route_code_lens_to_action(node)
-        class_name, _ = T.must(@constant_name_stack.last)
+        class_name, _ = @constant_name_stack.last #: as !nil
         route = @client.route(controller: class_name, action: node.name.to_s)
         return unless route
 
@@ -236,7 +236,9 @@ module RubyLsp
 
       #: -> String?
       def migration_version
-        File.basename(T.must(@path)).split("_").first
+        File.basename(
+          @path, #: as !nil
+        ).split("_").first
       end
 
       #: (Prism::Node node, name: String, command: String) -> void

--- a/lib/ruby_lsp/ruby_lsp_rails/completion.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/completion.rb
@@ -37,7 +37,7 @@ module RubyLsp
         return if resolved_class.nil?
 
         arguments = @node_context.call_node.arguments&.arguments
-        indexed_call_node_args = T.let({}, T::Hash[String, Prism::Node])
+        indexed_call_node_args = {} #: Hash[String, Prism::Node]
 
         if arguments
           indexed_call_node_args = index_call_node_args(arguments: arguments)

--- a/lib/ruby_lsp/ruby_lsp_rails/definition.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/definition.rb
@@ -35,7 +35,7 @@ module RubyLsp
         @client = client
         @response_builder = response_builder
         @node_context = node_context
-        @nesting = T.let(node_context.nesting, T::Array[String])
+        @nesting = node_context.nesting #: Array[String]
         @index = index
 
         dispatcher.register(self, :on_call_node_enter, :on_symbol_node_enter, :on_string_node_enter)
@@ -121,7 +121,9 @@ module RubyLsp
 
       #: (Prism::CallNode node) -> void
       def handle_route(node)
-        result = @client.route_location(T.must(node.message))
+        result = @client.route_location(
+          node.message, #: as !nil
+        )
         return unless result
 
         @response_builder << Support::LocationBuilder.line_location_from_s(result.fetch(:location))

--- a/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/document_symbol.rb
@@ -15,7 +15,7 @@ module RubyLsp
       #: (ResponseBuilders::DocumentSymbol response_builder, Prism::Dispatcher dispatcher) -> void
       def initialize(response_builder, dispatcher)
         @response_builder = response_builder
-        @namespace_stack = T.let([], T::Array[String])
+        @namespace_stack = [] #: Array[String]
 
         dispatcher.register(
           self,
@@ -45,14 +45,16 @@ module RubyLsp
         return if receiver && !receiver.is_a?(Prism::SelfNode)
 
         message = node.message
+        return unless message
+
         case message
         when *Support::Callbacks::ALL, "validate"
-          handle_all_arg_types(node, T.must(message))
+          handle_all_arg_types(node, message)
         when "validates", "validates!", "validates_each", "belongs_to", "has_one", "has_many",
           "has_and_belongs_to_many", "attr_readonly", "scope"
-          handle_symbol_and_string_arg_types(node, T.must(message))
+          handle_symbol_and_string_arg_types(node, message)
         when "validates_with"
-          handle_class_arg_types(node, T.must(message))
+          handle_class_arg_types(node, message)
         end
       end
 
@@ -113,7 +115,9 @@ module RubyLsp
             append_document_symbol(
               name: "#{message} :#{name}",
               range: range_from_location(argument.location),
-              selection_range: range_from_location(T.must(argument.value_loc)),
+              selection_range: range_from_location(
+                argument.value_loc, #: as !nil
+              ),
             )
           when Prism::StringNode
             name = argument.content
@@ -172,7 +176,9 @@ module RubyLsp
             append_document_symbol(
               name: "#{message} :#{name}",
               range: range_from_location(argument.location),
-              selection_range: range_from_location(T.must(argument.value_loc)),
+              selection_range: range_from_location(
+                argument.value_loc, #: as !nil
+              ),
             )
           when Prism::StringNode
             name = argument.content

--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -21,8 +21,8 @@ module RubyLsp
       def initialize(client, response_builder, node_context, global_state, dispatcher)
         @client = client
         @response_builder = response_builder
-        @nesting = T.let(node_context.nesting, T::Array[String])
-        @index = T.let(global_state.index, RubyIndexer::Index)
+        @nesting = node_context.nesting #: Array[String]
+        @index = global_state.index #: RubyIndexer::Index
         dispatcher.register(self, :on_constant_path_node_enter, :on_constant_read_node_enter)
       end
 

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -15,7 +15,7 @@ module RubyLsp
           full_files = []
 
           until queue.empty?
-            item = T.must(queue.shift)
+            item = queue.shift #: as !nil
             tags = Set.new(item[:tags])
             next unless tags.include?("framework:rails")
 

--- a/lib/ruby_lsp/ruby_lsp_rails/support/active_support_test_case_helper.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/active_support_test_case_helper.rb
@@ -19,7 +19,8 @@ module RubyLsp
           parts = first_argument.parts
 
           if parts.all? { |part| part.is_a?(Prism::StringNode) }
-            T.cast(parts, T::Array[Prism::StringNode]).map(&:content).join
+            parts #: as Array[Prism::StringNode]
+              .map(&:content).join
           end
         when Prism::StringNode
           first_argument.content

--- a/lib/ruby_lsp/ruby_lsp_rails/support/associations.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/associations.rb
@@ -5,15 +5,12 @@ module RubyLsp
   module Rails
     module Support
       module Associations
-        ALL = T.let(
-          [
-            "belongs_to",
-            "has_many",
-            "has_one",
-            "has_and_belongs_to_many",
-          ].freeze,
-          T::Array[String],
-        )
+        ALL = [
+          "belongs_to",
+          "has_many",
+          "has_one",
+          "has_and_belongs_to_many",
+        ].freeze
       end
     end
   end

--- a/lib/ruby_lsp/ruby_lsp_rails/support/callbacks.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/callbacks.rb
@@ -5,66 +5,57 @@ module RubyLsp
   module Rails
     module Support
       module Callbacks
-        MODELS = T.let(
-          [
-            "before_validation",
-            "after_validation",
-            "before_save",
-            "around_save",
-            "after_save",
-            "before_create",
-            "around_create",
-            "after_create",
-            "after_commit",
-            "after_create_commit",
-            "after_update_commit",
-            "after_destroy_commit",
-            "after_save_commit",
-            "after_rollback",
-            "before_update",
-            "around_update",
-            "after_update",
-            "before_destroy",
-            "around_destroy",
-            "after_destroy",
-            "after_initialize",
-            "after_find",
-            "after_touch",
-          ].freeze,
-          T::Array[String],
-        )
+        MODELS = [
+          "before_validation",
+          "after_validation",
+          "before_save",
+          "around_save",
+          "after_save",
+          "before_create",
+          "around_create",
+          "after_create",
+          "after_commit",
+          "after_create_commit",
+          "after_update_commit",
+          "after_destroy_commit",
+          "after_save_commit",
+          "after_rollback",
+          "before_update",
+          "around_update",
+          "after_update",
+          "before_destroy",
+          "around_destroy",
+          "after_destroy",
+          "after_initialize",
+          "after_find",
+          "after_touch",
+        ].freeze
 
-        CONTROLLERS = T.let(
-          [
-            "after_action",
-            "append_after_action",
-            "append_around_action",
-            "append_before_action",
-            "around_action",
-            "before_action",
-            "prepend_after_action",
-            "prepend_around_action",
-            "prepend_before_action",
-            "skip_after_action",
-            "skip_around_action",
-            "skip_before_action",
-          ].freeze,
-          T::Array[String],
-        )
+        CONTROLLERS = [
+          "after_action",
+          "append_after_action",
+          "append_around_action",
+          "append_before_action",
+          "around_action",
+          "before_action",
+          "prepend_after_action",
+          "prepend_around_action",
+          "prepend_before_action",
+          "skip_after_action",
+          "skip_around_action",
+          "skip_before_action",
+        ].freeze
 
-        JOBS = T.let(
-          [
-            "after_enqueue",
-            "after_perform",
-            "around_enqueue",
-            "around_perform",
-            "before_enqueue",
-            "before_perform",
-          ].freeze,
-          T::Array[String],
-        )
+        JOBS = [
+          "after_enqueue",
+          "after_perform",
+          "around_enqueue",
+          "around_perform",
+          "before_enqueue",
+          "before_perform",
+        ].freeze
 
-        ALL = T.let((MODELS + CONTROLLERS + JOBS).freeze, T::Array[String])
+        ALL = (MODELS + CONTROLLERS + JOBS).freeze #: Array[String]
       end
     end
   end

--- a/sorbet/config
+++ b/sorbet/config
@@ -5,3 +5,4 @@
 --ignore=test/dummy
 --enable-experimental-rbs-signatures
 --enable-experimental-rbs-assertions
+--enable-experimental-requires-ancestor

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ ENV["RAILS_ENV"] = "test"
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
-require "sorbet-runtime"
 require "rails/test_help"
 require "mocha/minitest"
 require "ruby_lsp/internal"


### PR DESCRIPTION
The changes in #585 were causing our tests to hang, so I reverted them as part of #599.

Thankfully, we no longer need those checks, now that we can fully migrate to the new RBS in comments syntax.

This PR fully moves the Rails add-on to use only comments, removing its need for the Sorbet runtime.

Once the Ruby LSP itself drops its need for the runtime, we can switch from using `sorbet-static-and-runtime` to just `sorbet-static`.