### PR TITLE
Remove unused runner client parameter from RailsTestStyle

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -91,7 +91,7 @@ module RubyLsp
       def create_discover_tests_listener(response_builder, dispatcher, uri)
         return unless @global_state
 
-        RailsTestStyle.new(@rails_runner_client, response_builder, @global_state, dispatcher, uri)
+        RailsTestStyle.new(response_builder, @global_state, dispatcher, uri)
       end
 
       # @override

--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -50,8 +50,8 @@ module RubyLsp
         end
       end
 
-      #: (RunnerClient client, ResponseBuilders::TestCollection response_builder, GlobalState global_state, Prism::Dispatcher dispatcher, URI::Generic uri) -> void
-      def initialize(client, response_builder, global_state, dispatcher, uri)
+      #: (ResponseBuilders::TestCollection response_builder, GlobalState global_state, Prism::Dispatcher dispatcher, URI::Generic uri) -> void
+      def initialize(response_builder, global_state, dispatcher, uri)
         super(response_builder, global_state, dispatcher, uri)
 
         dispatcher.register(


### PR DESCRIPTION
This parameter is not used for anything, so we can remove it.