### PR TITLE
Add hover information on associations

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/definition.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/definition.rb
@@ -109,7 +109,7 @@ module RubyLsp
 
         association_name = first_argument.unescaped
 
-        result = @client.association_target_location(
+        result = @client.association_target(
           model_name: @nesting.join("::"),
           association_name: association_name,
         )

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -144,9 +144,9 @@ module RubyLsp
       end
 
       #: (model_name: String, association_name: String) -> Hash[Symbol, untyped]?
-      def association_target_location(model_name:, association_name:)
+      def association_target(model_name:, association_name:)
         make_request(
-          "association_target_location",
+          "association_target",
           model_name: model_name,
           association_name: association_name,
         )

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -306,7 +306,7 @@ module RubyLsp
           with_request_error_handling(request) do
             send_result(resolve_database_info_from_model(params.fetch(:name)))
           end
-        when "association_target_location"
+        when "association_target"
           with_request_error_handling(request) do
             send_result(resolve_association_target(params))
           end
@@ -431,7 +431,7 @@ module RubyLsp
         source_location = Object.const_source_location(association_klass.to_s)
         return unless source_location
 
-        { location: "#{source_location[0]}:#{source_location[1]}" }
+        { location: "#{source_location[0]}:#{source_location[1]}", name: association_klass.name }
       rescue NameError
         nil
       end

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -218,6 +218,109 @@ module RubyLsp
         refute_match(/Schema/, response.contents.value)
       end
 
+      test "returns has_many association information" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/membership.rb:5",
+          name: "Bar",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 1, character: 11 })
+          class Foo < ApplicationRecord
+            has_many :bars
+          end
+
+          class Bar < ApplicationRecord
+            belongs_to :foo
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Bar
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L5,1-7,4)
+        CONTENT
+      end
+
+      test "returns belongs_to association information" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/membership.rb:1",
+          name: "Foo",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 5, character: 14 })
+          class Foo < ApplicationRecord
+            has_many :bars
+          end
+
+          class Bar < ApplicationRecord
+            belongs_to :foo
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Foo
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L1,1-3,4)
+        CONTENT
+      end
+
+      test "returns has_one association information" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/membership.rb:5",
+          name: "Bar",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 1, character: 10 })
+          class Foo < ApplicationRecord
+            has_one :bar
+          end
+
+          class Bar < ApplicationRecord
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Bar
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L5,1-6,4)
+        CONTENT
+      end
+
+      test "returns has_and_belongs_to association information" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/membership.rb:5",
+          name: "Bar",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 1, character: 26 })
+          class Foo < ApplicationRecord
+            has_and_belongs_to_many :bars
+          end
+
+          class Bar < ApplicationRecord
+            has_and_belongs_to_many :foos
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Bar
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L5,1-7,4)
+        CONTENT
+      end
+
       private
 
       def hover_on_source(source, position)

--- a/test/ruby_lsp_rails/server_test.rb
+++ b/test/ruby_lsp_rails/server_test.rb
@@ -55,43 +55,51 @@ class ServerTest < ActiveSupport::TestCase
 
   test "resolve association returns the location of the target class of a has_many association" do
     @server.execute(
-      "association_target_location",
+      "association_target",
       { model_name: "Organization", association_name: :memberships },
     )
     location = response[:result][:location]
+    name = response[:result][:name]
+    assert_equal "Membership", name
     assert_match %r{test/dummy/app/models/membership.rb:3$}, location
   end
 
   test "resolve association returns the location of the target class of a belongs_to association" do
     @server.execute(
-      "association_target_location",
+      "association_target",
       { model_name: "Membership", association_name: :organization },
     )
     location = response[:result][:location]
+    name = response[:result][:name]
+    assert_equal "Organization", name
     assert_match %r{test/dummy/app/models/organization.rb:3$}, location
   end
 
   test "resolve association returns the location of the target class of a has_one association" do
     @server.execute(
-      "association_target_location",
+      "association_target",
       { model_name: "User", association_name: :profile },
     )
     location = response[:result][:location]
+    name = response[:result][:name]
+    assert_equal "Profile", name
     assert_match %r{test/dummy/app/models/profile.rb:3$}, location
   end
 
   test "resolve association returns the location of the target class of a has_and_belongs_to_many association" do
     @server.execute(
-      "association_target_location",
+      "association_target",
       { model_name: "Profile", association_name: :labels },
     )
     location = response[:result][:location]
+    name = response[:result][:name]
+    assert_equal "Label", name
     assert_match %r{test/dummy/app/models/label.rb:3$}, location
   end
 
   test "resolve association handles invalid model name" do
     @server.execute(
-      "association_target_location",
+      "association_target",
       { model_name: "NotHere", association_name: :labels },
     )
     assert_nil(response.fetch(:result))
@@ -99,7 +107,7 @@ class ServerTest < ActiveSupport::TestCase
 
   test "resolve association handles invalid association name" do
     @server.execute(
-      "association_target_location",
+      "association_target",
       { model_name: "Membership", association_name: :labels },
     )
     assert_nil(response.fetch(:result))
@@ -107,10 +115,12 @@ class ServerTest < ActiveSupport::TestCase
 
   test "resolve association handles class_name option" do
     @server.execute(
-      "association_target_location",
+      "association_target",
       { model_name: "User", association_name: :location },
     )
     location = response[:result][:location]
+    name = response[:result][:name]
+    assert_equal "Country", name
     assert_match %r{test/dummy/app/models/country.rb:3$}, location
   end
 


### PR DESCRIPTION
Closes #476 

Add class information on hover in the associations for models. 

We provide the same information that hover on constants provide, but in the symbol of the associations.