### PR TITLE
Change rubocop rake to plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,10 +3,10 @@ inherit_gem:
 
 plugins:
  - rubocop-minitest
+ - rubocop-rake
 
 require:
  - rubocop-sorbet
- - rubocop-rake
 
 AllCops:
   NewCops: disable


### PR DESCRIPTION
[Realease 0.7.0](https://github.com/rubocop/rubocop-rake/releases/tag/v0.7.0) pluginified rubocop rake. This PR removes the deprecation warning by changing to the plugin syntax in `.rubocop.yml`.