### PR TITLE
Ensure we're keeping track of module nesting

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -94,6 +94,7 @@ module RubyLsp
       #: (Prism::ModuleNode node) -> void
       def on_module_node_enter(node)
         @parent_stack << nil
+        super
       end
 
       #: (Prism::ModuleNode node) -> void

--- a/test/ruby_lsp_rails/rails_test_style_test.rb
+++ b/test/ruby_lsp_rails/rails_test_style_test.rb
@@ -318,6 +318,25 @@ module RubyLsp
         end
       end
 
+      test "namespaced test" do
+        source = <<~RUBY
+          module Foo
+            class SampleTest < ActiveSupport::TestCase
+              test "do something" do
+              end
+            end
+          end
+        RUBY
+
+        with_active_support_declarative_tests(source) do |items|
+          assert_equal(["Foo::SampleTest"], items.map { |i| i[:id] })
+          assert_equal(
+            ["Foo::SampleTest#test_do_something"],
+            items.dig(0, :children).map { |i| i[:id] },
+          )
+        end
+      end
+
       private
 
       def with_active_support_declarative_tests(source, file: "/fake.rb", &block)


### PR DESCRIPTION
I introduced an issue in #612. I forgot to invoke `super` for the module event, which means we stopped tracking the right module nesting.

This PR just adds the missing `super` call with a test to prevent another regression.