### PR TITLE
Create parent stack before invoking super

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/rails_test_style.rb
@@ -52,9 +52,8 @@ module RubyLsp
 
       #: (ResponseBuilders::TestCollection response_builder, GlobalState global_state, Prism::Dispatcher dispatcher, URI::Generic uri) -> void
       def initialize(response_builder, global_state, dispatcher, uri)
+        @parent_stack = [response_builder] #: Array[(Requests::Support::TestItem | ResponseBuilders::TestCollection)?]
         super(response_builder, global_state, dispatcher, uri)
-
-        @parent_stack = [@response_builder] #: Array[(Requests::Support::TestItem | ResponseBuilders::TestCollection)?]
 
         dispatcher.register(
           self,


### PR DESCRIPTION
Somehow, we're seeing a race condition of the listener receiving events before it is fully initialized. Let's ensure that we create the stack before invoking super.