### PR TITLE
Use rubocop-sorbet as plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,9 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 plugins:
- - rubocop-minitest
- - rubocop-rake
-
-require:
- - rubocop-sorbet
+  - rubocop-minitest
+  - rubocop-rake
+  - rubocop-sorbet
 
 AllCops:
   NewCops: disable
@@ -16,7 +14,7 @@ AllCops:
 
 Naming/FileName:
   Exclude:
-  - "lib/ruby-lsp-rails.rb"
+    - "lib/ruby-lsp-rails.rb"
 
 Sorbet/FalseSigil:
   Enabled: false


### PR DESCRIPTION
Addresses:
```
rubocop-sorbet extension supports plugin, specify `plugins: rubocop-sorbet` instead of `require: rubocop-sorbet` in /Users/joshuayoung/Projects/Shopify/ruby-lsp-rails/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```