### PR TITLE
Add definition and hover support for `:through` associations

### DIFF
--- a/test/dummy/app/models/country.rb
+++ b/test/dummy/app/models/country.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Country < ApplicationRecord
+  has_one :flag, dependent: :destroy
 end

--- a/test/dummy/app/models/flag.rb
+++ b/test/dummy/app/models/flag.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Flag < ApplicationRecord
+  belongs_to :country
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   has_one :profile
   scope :adult, -> { where(age: 18..) }
-  has_one :location, class_name: "Country"
+  belongs_to :location, class_name: "Country"
+  has_one :country_flag, through: :location, source: :flag
 
   attr_readonly :last_name
 

--- a/test/dummy/db/migrate/20250703132109_create_flags.rb
+++ b/test/dummy/db/migrate/20250703132109_create_flags.rb
@@ -1,0 +1,9 @@
+class CreateFlags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :flags do |t|
+      t.references :country, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_25_225348) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_03_132109) do
   create_table "composite_primary_keys", primary_key: ["order_id", "product_id"], force: :cascade do |t|
     t.integer "order_id"
     t.integer "product_id"
@@ -23,6 +23,13 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_25_225348) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "flags", force: :cascade do |t|
+    t.integer "country_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["country_id"], name: "index_flags_on_country_id"
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -58,6 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_25_225348) do
     t.index ["country_id"], name: "index_users_on_country_id"
   end
 
+  add_foreign_key "flags", "countries"
   add_foreign_key "memberships", "organizations"
   add_foreign_key "memberships", "users"
   add_foreign_key "users", "countries"

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -321,6 +321,162 @@ module RubyLsp
         CONTENT
       end
 
+      test "returns main association on has_many :through association" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/user.rb:2",
+          name: "User",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 2, character: 14 })
+          class Organization < ApplicationRecord
+            has_many :memberships
+            has_many :users, through: :memberships
+          end
+
+          class User < ApplicationRecord
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          User
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L6,1-7,4)
+        CONTENT
+      end
+
+      test "returns through association on has_many :through association" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/membership.rb:3",
+          name: "Membership",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 2, character: 31 })
+          class Organization < ApplicationRecord
+            has_many :memberships
+            has_many :users, through: :memberships
+          end
+
+          class Membership < ApplicationRecord
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Membership
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L6,1-7,4)
+        CONTENT
+      end
+
+      test "returns main association on has_one :through association" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/flag.rb:2",
+          name: "Flag",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 2, character: 13 })
+          class User < ApplicationRecord
+            belongs_to :location, class_name: "Country"
+            has_one :country_flag, through: :location, source: :flag
+          end
+
+          class Flag < ApplicationRecord
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Flag
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L6,1-7,4)
+        CONTENT
+      end
+
+      test "returns through association on has_one :through association" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/country.rb:2",
+          name: "Country",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 2, character: 37 })
+          class User < ApplicationRecord
+            belongs_to :location, class_name: "Country"
+            has_one :country_flag, through: :location, source: :flag
+          end
+
+          class Country < ApplicationRecord
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Country
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L6,1-7,4)
+        CONTENT
+      end
+
+      test "returns string main association on has_many :through association" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/user.rb:2",
+          name: "User",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 2, character: 14 })
+          class Organization < ApplicationRecord
+            has_many :memberships
+            has_many "users", through: :memberships
+          end
+
+          class User < ApplicationRecord
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          User
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L6,1-7,4)
+        CONTENT
+      end
+
+      test "returns string through association on has_many :through association" do
+        expected_response = {
+          location: "#{dummy_root}/app/models/membership.rb:3",
+          name: "Membership",
+        }
+        RunnerClient.any_instance.stubs(association_target: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 2, character: 32 })
+          class Organization < ApplicationRecord
+            has_many "memberships"
+            has_many :users, through: "memberships"
+          end
+
+          class Membership < ApplicationRecord
+          end
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```ruby
+          Membership
+          ```
+
+          **Definitions**: [fake.rb](file:///fake.rb#L6,1-7,4)
+        CONTENT
+      end
+
       private
 
       def hover_on_source(source, position)


### PR DESCRIPTION
Currently, cmd + clicking on the through association name goes to the same file as the association name. I've added definition support to navigate to the correct through association model file.

I've also added hover support as a follow-up to https://github.com/Shopify/ruby-lsp-rails/pull/616.