### PR TITLE
Add hover on i18n translations

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -149,6 +149,10 @@ module RubyLsp
 
           offer_to_run_pending_migrations
         end
+
+        if changes.any? { |c| %r{config/locales/.*\.yml}.match?(c[:uri]) }
+          @rails_runner_client.trigger_i18n_reload
+        end
       end
 
       # @override
@@ -230,7 +234,7 @@ module RubyLsp
                 id: "workspace/didChangeWatchedFilesRails",
                 method: "workspace/didChangeWatchedFiles",
                 register_options: Interface::DidChangeWatchedFilesRegistrationOptions.new(
-                  watchers: [structure_sql_file_watcher, fixture_file_watcher],
+                  watchers: [structure_sql_file_watcher, fixture_file_watcher, i18n_file_watcher],
                 ),
               ),
             ],
@@ -250,6 +254,14 @@ module RubyLsp
       def fixture_file_watcher
         Interface::FileSystemWatcher.new(
           glob_pattern: "**/fixtures/**/*.{yml,yaml,yml.erb,yaml.erb}",
+          kind: Constant::WatchKind::CREATE | Constant::WatchKind::CHANGE | Constant::WatchKind::DELETE,
+        )
+      end
+
+      #: -> Interface::FileSystemWatcher
+      def i18n_file_watcher
+        Interface::FileSystemWatcher.new(
+          glob_pattern: "**/config/locales/**/*.{yml,yaml}",
           kind: Constant::WatchKind::CREATE | Constant::WatchKind::CHANGE | Constant::WatchKind::DELETE,
         )
       end

--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -29,6 +29,7 @@ module RubyLsp
           :on_constant_path_node_enter,
           :on_constant_read_node_enter,
           :on_symbol_node_enter,
+          :on_string_node_enter,
         )
       end
 
@@ -54,6 +55,11 @@ module RubyLsp
       #: (Prism::SymbolNode node) -> void
       def on_symbol_node_enter(node)
         handle_possible_dsl(node)
+      end
+
+      #: (Prism::StringNode node) -> void
+      def on_string_node_enter(node)
+        handle_possible_i18n(node)
       end
 
       private
@@ -148,6 +154,31 @@ module RubyLsp
         generate_hover(result[:name])
       end
 
+      #: (Prism::StringNode node) -> void
+      def handle_possible_i18n(node)
+        call_node = @node_context.call_node
+        return unless call_node
+
+        receiver = call_node.receiver
+        return unless receiver.is_a?(Prism::ConstantReadNode)
+        return unless receiver.name == :I18n
+
+        message = call_node.message
+        return unless message == "t"
+
+        first_argument = call_node.arguments&.arguments&.first
+        return unless first_argument.is_a?(Prism::StringNode)
+        return unless first_argument == node
+
+        i18n_key = first_argument.unescaped
+        return if i18n_key.empty?
+
+        result = @client.i18n(i18n_key)
+        return unless result
+
+        generate_i18n_hover(result)
+      end
+
       # Copied from `RubyLsp::Listeners::Hover#generate_hover`
       #: (String name) -> void
       def generate_hover(name)
@@ -163,6 +194,16 @@ module RubyLsp
         categorized_markdown_from_index_entries(full_name, entries).each do |category, content|
           @response_builder.push(content, category: category)
         end
+      end
+
+      #: (Hash[Symbol, String] translations) -> void
+      def generate_i18n_hover(translations)
+        content = translations.map { |lang, translation| "#{lang}: #{translation}" }.join("\n")
+        content = "```yaml\n#{content}\n```"
+        @response_builder.push(
+          content,
+          category: :documentation,
+        )
       end
     end
   end

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -180,6 +180,17 @@ module RubyLsp
         nil
       end
 
+      #: (String key) -> Hash[Symbol, untyped]?
+      def i18n(key)
+        make_request("i18n", key: key)
+      rescue MessageError
+        log_message(
+          "Ruby LSP Rails failed to get i18n information",
+          type: RubyLsp::Constant::MessageType::ERROR,
+        )
+        nil
+      end
+
       # Delegates a notification to a server add-on
       #: (server_addon_name: String, request_name: String, **untyped params) -> void
       def delegate_notification(server_addon_name:, request_name:, **params)
@@ -234,6 +245,18 @@ module RubyLsp
       rescue MessageError
         log_message(
           "Ruby LSP Rails failed to trigger reload",
+          type: RubyLsp::Constant::MessageType::ERROR,
+        )
+        nil
+      end
+
+      #: -> void
+      def trigger_i18n_reload
+        log_message("Reloading I18n translations")
+        send_notification("reload_i18n")
+      rescue MessageError
+        log_message(
+          "Ruby LSP Rails failed to trigger I18n reload",
           type: RubyLsp::Constant::MessageType::ERROR,
         )
         nil

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -332,6 +332,17 @@ module RubyLsp
           with_request_error_handling(request) do
             send_result(resolve_route_info(params))
           end
+        when "i18n"
+          with_request_error_handling(request) do
+            result = resolve_i18n_key(params.fetch(:key))
+            send_result(result)
+          end
+        when "reload_i18n"
+          with_progress("rails-reload-i18n", "Reloading Ruby LSP Rails I18n") do
+            with_notification_error_handling(request) do
+              I18n.reload! if defined?(I18n) && I18n.respond_to?(:reload!)
+            end
+          end
         when "server_addon/register"
           with_notification_error_handling(request) do
             require params[:server_addon_path]
@@ -524,6 +535,16 @@ module RubyLsp
         @database_supports_indexing = true
       rescue NotImplementedError
         @database_supports_indexing = false
+      end
+
+      #: (String) -> Hash[Symbol, String]
+      def resolve_i18n_key(key)
+        locales = I18n.available_locales
+        result = {}
+        locales.each.map do |locale|
+          result[locale] = I18n.t(key, locale: locale, default: "⚠️ translation missing")
+        end
+        result
       end
     end
   end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -16,4 +16,8 @@ class User < ApplicationRecord
   def foo
     puts "test"
   end
+
+  def hello
+    I18n.t("hello")
+  end
 end

--- a/test/dummy/config/locales/es.yml
+++ b/test/dummy/config/locales/es.yml
@@ -1,0 +1,3 @@
+---
+es:
+  hello: "Hola mundo"

--- a/test/dummy/config/locales/fr.yml
+++ b/test/dummy/config/locales/fr.yml
@@ -1,0 +1,3 @@
+---
+fr:
+  hello: "Bonjour le monde"

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -321,6 +321,28 @@ module RubyLsp
         CONTENT
       end
 
+      test "returns I18n translation information" do
+        expected_response = {
+          en: "hello",
+          es: "hola",
+          fr: "bonjour",
+        }
+
+        RunnerClient.any_instance.stubs(i18n: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 0, character: 9 })
+          I18n.t("foo")
+        RUBY
+
+        assert_equal(<<~CONTENT.chomp, response.contents.value)
+          ```yaml
+          en: hello
+          es: hola
+          fr: bonjour
+          ```
+        CONTENT
+      end
+
       private
 
       def hover_on_source(source, position)

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -66,6 +66,24 @@ module RubyLsp
         assert_match(%r{db/schema\.rb$}, response.fetch(:schema_file))
       end
 
+      test "#i18n returns translations for the requested key" do
+        RunnerClient.any_instance.stubs(model: "hello")
+        translations = @client.i18n("hello") #: as !nil
+        assert_instance_of(Hash, translations)
+        assert_equal("Hello world", translations[:en])
+        assert_equal("Hola mundo", translations[:es])
+        assert_equal("Bonjour le monde", translations[:fr])
+      end
+
+      test "#i18n returns translation missing for a key" do
+        RunnerClient.any_instance.stubs(model: "hello")
+        translations = @client.i18n("missing_key") #: as !nil
+        assert_instance_of(Hash, translations)
+        assert_equal("⚠️ translation missing", translations[:en])
+        assert_equal("⚠️ translation missing", translations[:es])
+        assert_equal("⚠️ translation missing", translations[:fr])
+      end
+
       test "returns nil if the request returns a nil response" do
         assert_nil @client.model("ApplicationRecord") # ApplicationRecord is abstract
       end


### PR DESCRIPTION
First implementation for I18n support (#639)

## How it works

1. Attach file watcher for all translation files
2. Add server request to reload translations on file changes. The reload is fast because does not need to reload the entire rails server, just the I18n.
3. Add server request to get I18n translations for all locales
4. On hover of `I18n.t("hello")` key string argument, request the server all the translations available and provide hover info for that.

It address points 1 and 2 of the issue list:

1. Read what the translation says. e.g., I18n.t("hello") returns en: "Hello World", es: "¡Hola Mundo!".
2. Find out if a translation is missing.

And is usefull for updating and creating translations because it gives feedback that the used translations "is correct" because makes direct calls to the I18n backend while typing and hovering it. Warning if the translation is missing.

This gives the following experience: 
[Screencast from 2025-07-27 00-40-33.webm](https://github.com/user-attachments/assets/8efa6f59-f5b6-4006-b1f5-6e75c32f2f15)



