### PR TITLE
Fix `undefined method 'join' for an instance of String` on hover

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -97,7 +97,15 @@ module RubyLsp
           @response_builder.push(
             model[:indexes].map do |index|
               uniqueness = index[:unique] ? " (unique)" : ""
-              "- **#{index[:name]}** (#{index[:columns].join(",")})#{uniqueness}"
+              columns = case index[:columns]
+                        when Array
+                          index[:columns].join(",")
+                        when String
+                          index[:columns]
+                        else
+                          index[:name]
+                        end
+              "- **#{index[:name]}** (#{columns})#{uniqueness}"
             end.join("\n"),
             category: :documentation,
           )

--- a/test/dummy/db/migrate/20250816140957_add_complex_index_to_users.rb
+++ b/test/dummy/db/migrate/20250816140957_add_complex_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddComplexIndexToUsers < ActiveRecord::Migration[8.0]
+  def change
+    execute "CREATE UNIQUE INDEX users_unique_complex ON users (COALESCE(country_id, 0), ltrim(first_name));"
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_25_225348) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_16_140957) do
   create_table "composite_primary_keys", primary_key: ["order_id", "product_id"], force: :cascade do |t|
     t.integer "order_id"
     t.integer "product_id"
@@ -55,6 +55,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_25_225348) do
     t.datetime "updated_at", null: false
     t.integer "country_id", null: false
     t.boolean "active", default: true, null: false
+    t.index "COALESCE(country_id, 0), ltrim(first_name)", name: "users_unique_complex", unique: true
     t.index ["country_id"], name: "index_users_on_country_id"
   end
 


### PR DESCRIPTION
Working on a project that has lots of indexes created via raw sql, for example
```sql
execute "CREATE UNIQUE INDEX users_unique_complex ON users (COALESCE(country_id, 0), ltrim(first_name));"
```
I saw this exception on the lsp logs
```
/home/user/.asdf/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/ruby-lsp-rails-0.4.8/lib/ruby_lsp/ruby_lsp_rails/hover.rb:100:in 'block in RubyLsp::Rails::Hover#generate_column_content': undefined method 'join' for an instance of String (NoMethodError)

              "- **#{index[:name]}** (#{index[:columns].join(",")})#{uniqueness}"
                                                       ^^^^^
```

This pr attempts to handle that exception but I'm not familiar with the whole project structure so maybe the issue should be fixed somewhere upstream?