### PR TITLE
Add go to definition support for `through:` and `class_name:` association options

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -129,7 +129,7 @@ module RubyLsp
       def create_definition_listener(response_builder, uri, node_context, dispatcher)
         return unless @global_state
 
-        Definition.new(@rails_runner_client, response_builder, node_context, @global_state.index, dispatcher)
+        Definition.new(@rails_runner_client, response_builder, node_context, @global_state.index, dispatcher, uri)
       end
 
       # @override


### PR DESCRIPTION
## `through:` option

When clicking on the `through:` value, it now navigates to the association definition in the same file:

```ruby
class Organization < ActiveRecord::Base
  has_many :memberships
  has_many :users, through: :memberships
  #                         ^^^^^^^^^^^^
  #                         go to definition -> has_many :memberships (line above)
end
```

This implements the behaviour mentioned in the Rafael's comment below - navigating to the association declaration rather than the model, since `through:` references another association, not a model directly.

## `class_name:` option

When clicking on the `class_name:` value, it navigates to that class using the index (no server call needed):

```ruby
class User < ActiveRecord::Base
  has_one :location, class_name: "Country"
  #                              ^^^^^^^^^
  #                              go to definition -> Country class
end
```

Additionally, when clicking on the association name that has a `class_name:` specified, it uses the index directly instead of making a server call:

```ruby
class User < ActiveRecord::Base
  has_one :location, class_name: "Country"
  #       ^^^^^^^^^
  #       go to definition -> Country class (via index, no server call)
end
```

This provides a small performance optimization since we can resolve the class name directly from the code without asking Rails for reflection data.

---

Closes #676