### PR TITLE
Use Prism parser for Sorbet

### DIFF
--- a/sorbet/config
+++ b/sorbet/config
@@ -5,3 +5,4 @@
 --ignore=test/dummy
 --enable-experimental-rbs-comments
 --enable-experimental-requires-ancestor
+--parser=prism


### PR DESCRIPTION
Adds `--parser=prism` to `sorbet/config` to use the Prism parser instead of the legacy Whitequark parser.