### PR TITLE
Migrate go to definition to Rubydex

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -129,7 +129,7 @@ module RubyLsp
       def create_definition_listener(response_builder, uri, node_context, dispatcher)
         return unless @global_state
 
-        Definition.new(@rails_runner_client, response_builder, node_context, @global_state.index, dispatcher)
+        Definition.new(@rails_runner_client, response_builder, node_context, @global_state.graph, dispatcher)
       end
 
       # @override

--- a/lib/ruby_lsp/ruby_lsp_rails/definition.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/definition.rb
@@ -30,13 +30,19 @@ module RubyLsp
     class Definition
       include Requests::Support::Common
 
-      #: (RunnerClient client, RubyLsp::ResponseBuilders::CollectionResponseBuilder[(Interface::Location | Interface::LocationLink)] response_builder, NodeContext node_context, RubyIndexer::Index index, Prism::Dispatcher dispatcher) -> void
-      def initialize(client, response_builder, node_context, index, dispatcher)
+      #: (
+      #|   RunnerClient,
+      #|   RubyLsp::ResponseBuilders::CollectionResponseBuilder[(Interface::Location | Interface::LocationLink)],
+      #|   NodeContext,
+      #|   Rubydex::Graph,
+      #|   Prism::Dispatcher
+      #| ) -> void
+      def initialize(client, response_builder, node_context, graph, dispatcher)
         @client = client
         @response_builder = response_builder
         @node_context = node_context
         @nesting = node_context.nesting #: Array[String]
-        @index = index
+        @graph = graph
 
         dispatcher.register(self, :on_call_node_enter, :on_symbol_node_enter, :on_string_node_enter)
       end
@@ -154,14 +160,19 @@ module RubyLsp
 
       #: (String name) -> void
       def collect_definitions(name)
-        methods = @index.resolve_method(name, @nesting.join("::"))
-        return unless methods
+        return if @nesting.empty?
 
-        methods.each do |target_method|
-          @response_builder << Interface::Location.new(
-            uri: target_method.uri.to_s,
-            range: range_from_location(target_method.location),
-          )
+        owner = @graph.resolve_constant(
+          @nesting.last, #: as !nil
+          @nesting[0...-1], #: as !nil
+        )
+        return unless owner.is_a?(Rubydex::Namespace)
+
+        declaration = owner.find_member("#{name}()")
+        return unless declaration
+
+        declaration.definitions.each do |definition|
+          @response_builder << definition.to_lsp_selection_location
         end
       end
 

--- a/test/ruby_lsp_rails/definition_test.rb
+++ b/test/ruby_lsp_rails/definition_test.rb
@@ -467,6 +467,71 @@ module RubyLsp
         assert_equal(15, response.range.end.character)
       end
 
+      test "resolves callback methods defined in included modules and superclasses" do
+        source = <<~RUBY
+          # typed: false
+
+          module Foo
+            module Shared
+              def shared_callback; end
+            end
+
+            class BaseController
+              def base_callback; end
+            end
+
+            class UsersController < BaseController
+              include Shared
+
+              before_action :shared_callback
+              before_action :base_callback
+            end
+          end
+        RUBY
+
+        response = generate_definitions_for_source(source, { line: 14, character: 22 })
+        assert_equal(1, response.size)
+        assert_equal("file:///fake.rb", response[0].uri)
+        assert_equal(4, response[0].range.start.line)
+        assert_equal(4, response[0].range.start.character)
+        assert_equal(4, response[0].range.end.line)
+        assert_equal(28, response[0].range.end.character)
+
+        response = generate_definitions_for_source(source, { line: 15, character: 22 })
+        assert_equal(1, response.size)
+        assert_equal("file:///fake.rb", response[0].uri)
+        assert_equal(8, response[0].range.start.line)
+        assert_equal(4, response[0].range.start.character)
+        assert_equal(8, response[0].range.end.line)
+        assert_equal(26, response[0].range.end.character)
+      end
+
+      test "resolves callbacks when the enclosing class uses a compact constant path" do
+        source = <<~RUBY
+          # typed: false
+
+          module Bar
+            class UsersController
+              def callback; end
+            end
+          end
+
+          module Foo
+            class Bar::UsersController
+              before_action :callback
+            end
+          end
+        RUBY
+
+        response = generate_definitions_for_source(source, { line: 10, character: 22 })
+        assert_equal(1, response.size)
+        assert_equal("file:///fake.rb", response[0].uri)
+        assert_equal(4, response[0].range.start.line)
+        assert_equal(4, response[0].range.start.character)
+        assert_equal(4, response[0].range.end.line)
+        assert_equal(21, response[0].range.end.character)
+      end
+
       private
 
       def generate_definitions_for_source(source, position)


### PR DESCRIPTION
This PR migrates go to definition to use Rubydex.