### PR TITLE
Fix intermittent server boot failure caused by working directory race

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -58,6 +58,13 @@ module RubyLsp
         @addon_mutex.synchronize { @rails_runner_client }
       end
 
+      # Blocks until the add-on finished booting the Rails runner client, successfully or not. After this method
+      # returns, `rails_runner_client` is in its final state: a working client or a NullClient if booting failed
+      #: -> void
+      def join_boot_thread
+        @boot_thread.join
+      end
+
       # @override
       #: (GlobalState global_state, Thread::Queue outgoing_queue) -> void
       def activate(global_state, outgoing_queue)
@@ -77,7 +84,7 @@ module RubyLsp
       # @override
       #: -> void
       def deactivate
-        @boot_thread.join
+        join_boot_thread
         @rails_runner_client.shutdown
       end
 

--- a/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/runner_client.rb
@@ -10,13 +10,15 @@ module RubyLsp
       class << self
         #: (Thread::Queue outgoing_queue, RubyLsp::GlobalState global_state) -> RunnerClient
         def create_client(outgoing_queue, global_state)
-          if File.exist?("bin/rails")
+          workspace_path = global_state.workspace_path
+
+          if File.exist?(File.join(workspace_path, "bin", "rails"))
             new(outgoing_queue, global_state)
           else
             unless outgoing_queue.closed?
               outgoing_queue << RubyLsp::Notification.window_log_message(
                 <<~MESSAGE.chomp,
-                  Ruby LSP Rails failed to locate bin/rails in the current directory: #{Dir.pwd}
+                  Ruby LSP Rails failed to locate bin/rails in the workspace: #{workspace_path}
                   Server dependent features will not be available
                 MESSAGE
                 type: RubyLsp::Constant::MessageType::WARNING,
@@ -64,6 +66,7 @@ module RubyLsp
             "#{__dir__}/server.rb",
             "start",
             server_relevant_capabilities(global_state),
+            { chdir: global_state.workspace_path },
           )
         end
 

--- a/test/ruby_lsp_rails/code_lens_test.rb
+++ b/test/ruby_lsp_rails/code_lens_test.rb
@@ -402,7 +402,7 @@ module RubyLsp
 
       def generate_code_lens_for_source(source, file: "/fake.rb")
         with_server(source, URI(file)) do |server, uri|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message(
             id: 1,

--- a/test/ruby_lsp_rails/completion_test.rb
+++ b/test/ruby_lsp_rails/completion_test.rb
@@ -60,7 +60,7 @@ module RubyLsp
 
       def generate_completions_for_source(source, position)
         with_server(source) do |server, uri|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message(
             id: 1,

--- a/test/ruby_lsp_rails/definition_test.rb
+++ b/test/ruby_lsp_rails/definition_test.rb
@@ -536,7 +536,7 @@ module RubyLsp
 
       def generate_definitions_for_source(source, position)
         with_server(source) do |server, uri|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message(
             id: 1,

--- a/test/ruby_lsp_rails/rails_test_style_test.rb
+++ b/test/ruby_lsp_rails/rails_test_style_test.rb
@@ -142,7 +142,7 @@ module RubyLsp
         Dir.stubs(:glob).returns(test_paths)
 
         with_server do |server|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message({
             id: 1,
@@ -181,7 +181,7 @@ module RubyLsp
 
       test "resolve test command group test" do
         with_server do |server|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message({
             id: 1,
@@ -230,7 +230,7 @@ module RubyLsp
 
       test "resolve test escapes file paths in groups" do
         with_server do |server|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message({
             id: 1,
@@ -264,7 +264,7 @@ module RubyLsp
 
       test "resolve test escapes single file paths" do
         with_server do |server|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message({
             id: 1,
@@ -298,7 +298,7 @@ module RubyLsp
         Dir.stubs(:glob).returns([test_path])
 
         with_server do |server|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message({
             id: 1,
@@ -328,7 +328,7 @@ module RubyLsp
 
       test "resolve test escapes file paths for specific examples" do
         with_server do |server|
-          sleep(0.1) while RubyLsp::Addon.addons.first.instance_variable_get(:@rails_runner_client).is_a?(NullClient)
+          wait_for_rails_runner_client_boot
 
           server.process_message({
             id: 1,

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -101,7 +101,7 @@ module RubyLsp
           log = pop_log_notification(outgoing_queue, RubyLsp::Constant::MessageType::WARNING)
 
           assert_instance_of(RubyLsp::Notification, log)
-          assert_match("Ruby LSP Rails failed to locate bin/rails in the current directory", log.params.message)
+          assert_match("Ruby LSP Rails failed to locate bin/rails in the workspace", log.params.message)
         ensure
           outgoing_queue.close
           FileUtils.mv("bin/rails_backup", "bin/rails")

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "tmpdir"
 require "ruby_lsp/ruby_lsp_rails/runner_client"
 
 module RubyLsp
@@ -105,6 +106,24 @@ module RubyLsp
         ensure
           outgoing_queue.close
           FileUtils.mv("bin/rails_backup", "bin/rails")
+        end
+      end
+
+      test "creates a client when the current working directory is not the workspace" do
+        outgoing_queue = Thread::Queue.new
+
+        client = Dir.mktmpdir do |dir|
+          Dir.chdir(dir) { RunnerClient.create_client(outgoing_queue, @global_state) }
+        end
+
+        begin
+          refute_instance_of(NullClient, client)
+
+          response = client.model("User") #: as !nil
+          assert(response.key?(:columns))
+        ensure
+          client.shutdown
+          outgoing_queue.close
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,5 +20,15 @@ module ActiveSupport
     def dummy_root
       File.expand_path("#{__dir__}/dummy")
     end
+
+    # Waits until the Rails add-on finished booting the runner client and fails the test immediately if it fell back
+    # to a NullClient, instead of hanging forever waiting for a real client that will never arrive
+    def wait_for_rails_runner_client_boot
+      addon = RubyLsp::Addon.addons.first #: as RubyLsp::Rails::Addon
+      addon.join_boot_thread
+
+      client = addon.rails_runner_client
+      refute_instance_of(RubyLsp::Rails::NullClient, client, "Expected the Rails runner client to boot successfully")
+    end
   end
 end


### PR DESCRIPTION
### Motivation

CI hangs intermittently on Ruby 4.0.6 (first seen in #724 / #725) — jobs time out after 25 minutes with the test suite stuck mid-run. The cause is a working-directory race in `RunnerClient.create_client`, not setup-ruby or gem updates.

`create_client` checks `File.exist?("bin/rails")` relative to the process working directory, and spawns the `rails runner` server with the inherited cwd. But the working directory is process-global state that other threads mutate: RuboCop's config loader evaluates configs with `Dir.chdir(config dir) { ERB.new(...).result }` while resolving `inherit_gem`. When the Ruby LSP RuboCop addon activates concurrently with the Rails addon boot thread, the boot thread can observe the `rubocop-shopify` gem directory as cwd. The `bin/rails` check then fails and `create_client` silently falls back to a `NullClient`.

The race is long-standing but almost never fired until Ruby 4.0.6, whose thread-scheduler changes ([Bug #21685](https://bugs.ruby-lang.org/issues/21685) backport) altered thread interleaving enough to make it fire several times per 100 boots on CI runners. That's why bumping setup-ruby past 1.317.0 (which resolves `"4.0"` to 4.0.6 instead of 4.0.5) broke CI. Trace from a failing boot captured in the investigation PR (#726, now closed):

```
[RuboCop] Activating RuboCop LSP addon 1.88.2.
Ruby LSP Rails create_client start (cwd=.../vendor/bundle/ruby/4.0.0/gems/rubocop-shopify-2.18.0)
Ruby LSP Rails create_client: bin/rails NOT found (cwd=.../gems/rubocop-shopify-2.18.0)
[RuboCop] Initialized RuboCop LSP addon 1.88.2.
```

Note that the hang itself only happens in this repo's test suite: several tests busy-wait with `sleep(0.1) while ...NullClient` for the real client to boot, and the loop never terminates when boot fails because `NullClient` is the final state. In real editor usage a boot failure does not hang anything — the add-on falls back to the `NullClient`, logs a warning, and Rails-dependent features are silently unavailable.

### Implementation

- Resolve `bin/rails` against `global_state.workspace_path` instead of the cwd, and spawn the server with an explicit `chdir:` to the workspace path, so neither depends on racy process-global state.
- Fix the tests' unbounded busy-wait as well: add `Addon#join_boot_thread` so the boot outcome can be awaited deterministically, and make the tests join the boot thread and assert that the client actually booted. A boot failure now fails the test immediately with a clear message instead of hanging the suite until the CI timeout.