### PR TITLE
Link schema hover to the model's table definition

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rails/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/addon.rb
@@ -9,6 +9,7 @@ require_relative "support/associations"
 require_relative "support/callbacks"
 require_relative "support/validations"
 require_relative "support/location_builder"
+require_relative "support/schema_table_location_visitor"
 require_relative "runner_client"
 require_relative "hover"
 require_relative "code_lens"
@@ -149,6 +150,7 @@ module RubyLsp
       def workspace_did_change_watched_files(changes)
         if changes.any? { |c| c[:uri].end_with?("db/schema.rb") || c[:uri].end_with?("structure.sql") }
           @rails_runner_client.trigger_reload
+          Support::SchemaTableLocationVisitor.expire_cache
         end
 
         if changes.any? do |c|

--- a/lib/ruby_lsp/ruby_lsp_rails/hover.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/hover.rb
@@ -73,7 +73,7 @@ module RubyLsp
         schema_file = model[:schema_file]
 
         @response_builder.push(
-          "[Schema](#{URI::Generic.from_path(path: schema_file)})\n",
+          "[Schema](#{schema_uri(schema_file, model[:table_name])})\n",
           category: :documentation,
         ) if schema_file
 
@@ -117,6 +117,26 @@ module RubyLsp
             category: :documentation,
           )
         end
+      end
+
+      #: (String schema_file, String? table_name) -> String
+      def schema_uri(schema_file, table_name)
+        location = table_name && table_location(schema_file, table_name)
+
+        fragment = if location
+          "L#{location.start_line},#{location.start_column + 1}-#{location.end_line},#{location.end_column + 1}"
+        end
+
+        URI::Generic.from_path(path: schema_file, fragment: fragment).to_s
+      end
+
+      #: (String schema_file, String table_name) -> Prism::Location?
+      def table_location(schema_file, table_name)
+        return unless File.extname(schema_file) == ".rb"
+
+        Support::SchemaTableLocationVisitor.find(File.read(schema_file), table_name)
+      rescue Errno::ENOENT, Errno::EACCES
+        nil
       end
 
       #: (String default_value, String type) -> String

--- a/lib/ruby_lsp/ruby_lsp_rails/server.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/server.rb
@@ -427,6 +427,7 @@ module RubyLsp
         return unless active_record_model?(const)
 
         info = {
+          table_name: const.table_name,
           columns: const.columns.map { |column| [column.name, column.type, column.default, column.null] },
           primary_keys: Array(const.primary_key),
           foreign_keys: collect_model_foreign_keys(const),

--- a/lib/ruby_lsp/ruby_lsp_rails/support/schema_table_location_visitor.rb
+++ b/lib/ruby_lsp/ruby_lsp_rails/support/schema_table_location_visitor.rb
@@ -1,0 +1,62 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Rails
+    module Support
+      class SchemaTableLocationVisitor < Prism::Visitor
+        class << self
+          #: (String source, String table_name) -> Prism::Location?
+          def find(source, table_name)
+            table_locations(source)[table_name]
+          end
+
+          #: -> void
+          def expire_cache
+            @cache.clear
+          end
+
+          private
+
+          #: (String source) -> Hash[String, Prism::Location]
+          def table_locations(source)
+            @cache[source] ||= begin
+              visitor = new
+              Prism.parse(source).value.accept(visitor)
+              visitor.tables
+            end
+          end
+        end
+
+        @cache = {} #: Hash[String, Hash[String, Prism::Location]]
+
+        #: -> void
+        def initialize
+          super
+          @tables = {} #: Hash[String, Prism::Location]
+        end
+
+        #: Hash[String, Prism::Location]
+        attr_reader :tables
+
+        #: (Prism::CallNode node) -> void
+        def visit_call_node(node)
+          if node.message == "create_table"
+            first_argument = node.arguments&.arguments&.first
+
+            name = case first_argument
+            when Prism::StringNode
+              first_argument.unescaped
+            when Prism::SymbolNode
+              first_argument.unescaped
+            end
+
+            @tables[name] = node.location if name
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/test/ruby_lsp_rails/addon_test.rb
+++ b/test/ruby_lsp_rails/addon_test.rb
@@ -50,6 +50,32 @@ module RubyLsp
         addon.workspace_did_change_watched_files(changes)
       end
 
+      test "expires the schema table location cache if db/schema.rb is changed" do
+        changes = [
+          {
+            uri: "file://#{dummy_root}/db/schema.rb",
+            type: RubyLsp::Constant::FileChangeType::CHANGED,
+          },
+        ]
+
+        Support::SchemaTableLocationVisitor.expects(:expire_cache).once
+        addon = Addon.new
+        addon.workspace_did_change_watched_files(changes)
+      end
+
+      test "does not expire the schema table location cache if schema is not changed" do
+        changes = [
+          {
+            uri: "file://#{dummy_root}/app/models/foo.rb",
+            type: RubyLsp::Constant::FileChangeType::CHANGED,
+          },
+        ]
+
+        Support::SchemaTableLocationVisitor.expects(:expire_cache).never
+        addon = Addon.new
+        addon.workspace_did_change_watched_files(changes)
+      end
+
       test "handling window show message response to run migrations" do
         RunnerClient.any_instance.expects(:run_migrations).once.returns({ message: "Ran migrations!", status: 0 })
         outgoing_queue = Thread::Queue.new

--- a/test/ruby_lsp_rails/hover_test.rb
+++ b/test/ruby_lsp_rails/hover_test.rb
@@ -65,6 +65,81 @@ module RubyLsp
         CONTENT
       end
 
+      test "schema link points to the model's table definition when the table name is known" do
+        expected_response = {
+          schema_file: "#{dummy_root}/db/schema.rb",
+          table_name: "users",
+          columns: [],
+          primary_keys: ["id"],
+          foreign_keys: [],
+          indexes: [],
+        }
+
+        RunnerClient.any_instance.stubs(model: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 3, character: 0 })
+          class User < ApplicationRecord
+          end
+
+          User
+        RUBY
+
+        assert_includes(
+          response.contents.value,
+          "[Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")}#L50,3-60,6)",
+        )
+      end
+
+      test "schema link falls back to the top of the file when the table can't be found in the schema" do
+        expected_response = {
+          schema_file: "#{dummy_root}/db/schema.rb",
+          table_name: "non_existing_table",
+          columns: [],
+          primary_keys: ["id"],
+          foreign_keys: [],
+          indexes: [],
+        }
+
+        RunnerClient.any_instance.stubs(model: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 3, character: 0 })
+          class User < ApplicationRecord
+          end
+
+          User
+        RUBY
+
+        assert_includes(
+          response.contents.value,
+          "[Schema](#{URI::Generic.from_path(path: dummy_root + "/db/schema.rb")})",
+        )
+      end
+
+      test "schema link falls back to the top of the file when the schema file can't be read" do
+        expected_response = {
+          schema_file: "#{dummy_root}/db/does_not_exist.rb",
+          table_name: "users",
+          columns: [],
+          primary_keys: ["id"],
+          foreign_keys: [],
+          indexes: [],
+        }
+
+        RunnerClient.any_instance.stubs(model: expected_response)
+
+        response = hover_on_source(<<~RUBY, { line: 3, character: 0 })
+          class User < ApplicationRecord
+          end
+
+          User
+        RUBY
+
+        assert_includes(
+          response.contents.value,
+          "[Schema](#{URI::Generic.from_path(path: dummy_root + "/db/does_not_exist.rb")})",
+        )
+      end
+
       test "return column information for namespaced models" do
         expected_response = {
           schema_file: "#{dummy_root}/db/schema.rb",

--- a/test/ruby_lsp_rails/runner_client_test.rb
+++ b/test/ruby_lsp_rails/runner_client_test.rb
@@ -61,6 +61,7 @@ module RubyLsp
           { name: "index_users_on_country_id", columns: ["country_id"], unique: false },
         ]
         response = @client.model("User") #: as !nil
+        assert_equal("users", response.fetch(:table_name))
         assert_equal(columns, response.fetch(:columns))
         assert_equal(foreign_keys, response.fetch(:foreign_keys))
         assert_equal(indexes.sort_by { |i| i[:name] }, response.fetch(:indexes).sort_by { |i| i[:name] })

--- a/test/ruby_lsp_rails/support/schema_table_location_visitor_test.rb
+++ b/test/ruby_lsp_rails/support/schema_table_location_visitor_test.rb
@@ -1,0 +1,85 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyLsp
+  module Rails
+    module Support
+      class SchemaTableLocationVisitorTest < ActiveSupport::TestCase
+        # The cache is process wide, so don't leave entries behind for the other tests to pick up
+        teardown do
+          SchemaTableLocationVisitor.expire_cache
+        end
+
+        test ".find returns the location of a table defined with a string name" do
+          source = <<~RUBY
+            ActiveRecord::Schema[7.1].define(version: 1) do
+              create_table "users", force: :cascade do |t|
+                t.string "name"
+              end
+
+              create_table "posts", force: :cascade do |t|
+                t.string "title"
+              end
+            end
+          RUBY
+
+          location = SchemaTableLocationVisitor.find(source, "posts") #: as !nil
+
+          assert_equal(6, location.start_line)
+          assert_equal(8, location.end_line)
+        end
+
+        test ".find returns the location of a table defined with a symbol name" do
+          source = <<~RUBY
+            ActiveRecord::Schema[7.1].define(version: 1) do
+              create_table :users, force: :cascade do |t|
+                t.string "name"
+              end
+
+              create_table :posts, force: :cascade do |t|
+                t.string "title"
+              end
+            end
+          RUBY
+
+          location = SchemaTableLocationVisitor.find(source, "posts") #: as !nil
+
+          assert_equal(6, location.start_line)
+          assert_equal(8, location.end_line)
+        end
+
+        test ".find returns nil if the table is not found" do
+          assert_nil(SchemaTableLocationVisitor.find(schema_source, "non_existing_table"))
+        end
+
+        test ".find does not parse the same source again while it is cached" do
+          assert(SchemaTableLocationVisitor.find(schema_source, "users"))
+
+          Prism.expects(:parse).never
+
+          assert(SchemaTableLocationVisitor.find(schema_source, "users"))
+        end
+
+        test ".expire_cache makes the next lookup parse the source again" do
+          assert(SchemaTableLocationVisitor.find(schema_source, "users"))
+
+          SchemaTableLocationVisitor.expire_cache
+
+          # Parsed up front because the stub below counts every call, including the one setting it up
+          empty_result = Prism.parse("")
+          Prism.expects(:parse).once.returns(empty_result)
+
+          assert_nil(SchemaTableLocationVisitor.find(schema_source, "users"))
+        end
+
+        private
+
+        def schema_source
+          @schema_source ||= File.read("#{dummy_root}/db/schema.rb")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #52.

The `Schema` link in a model's hover opens `db/schema.rb` at the top, so you still have to find the
table yourself. This makes it jump to the model's `create_table` block.

This was already being worked on in #212, which takes a similar approach. That PR is still open but
has had no activity since March 2024, so rather than leave the issue sitting I put together a fresh
implementation. Happy to close this in favour of #212 if it's still moving.